### PR TITLE
Provide human-readable timestamps in changes_timestamps check

### DIFF
--- a/checks/remotesettings/changes_timestamps.py
+++ b/checks/remotesettings/changes_timestamps.py
@@ -31,21 +31,20 @@ async def run(request, server):
         for entry in entries
     ]
     results = await asyncio.gather(*futures)
-    all_good = True
+
     datetimes = []
-    for (entry, timestamp) in zip(entries, results):
-        collection_timestamp = timestamp
-        entry_timestamp = str(entry["last_modified"])
-        all_good = all_good and collection_timestamp == entry_timestamp
-        dt = datetime.utcfromtimestamp(int(timestamp) / 1000).isoformat()
-        cid = "{bucket}/{collection}".format(**entry)
+    for (entry, collection_timestamp) in zip(entries, results):
+        entry_timestamp = entry["last_modified"]
+        collection_timestamp = int(collection_timestamp)
+        dt = datetime.utcfromtimestamp(collection_timestamp / 1000).isoformat()
         datetimes.append(
             {
-                "id": cid,
+                "id": "{bucket}/{collection}".format(**entry),
                 "collection": collection_timestamp,
                 "entry": entry_timestamp,
                 "datetime": dt,
             }
         )
 
+    all_good = all([r["entry"] == r["collection"] for r in datetimes])
     return all_good, datetimes

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -24,7 +24,14 @@ async def test_positive(mocked_responses):
     status, data = await run(None, server_url)
 
     assert status is True
-    assert data == []
+    assert data == [
+        {
+            "collection": "42",
+            "datetime": "1970-01-01T00:00:00.042000",
+            "entry": "42",
+            "id": "bid/cid",
+        }
+    ]
 
 
 async def test_negative(mocked_responses):
@@ -45,4 +52,11 @@ async def test_negative(mocked_responses):
     status, data = await run(None, server_url)
 
     assert status is False
-    assert data == ["bid/cid"]
+    assert data == [
+        {
+            "id": "bid/cid",
+            "collection": "123",
+            "entry": "42",
+            "datetime": "1970-01-01T00:00:00.123000",
+        }
+    ]

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -26,9 +26,9 @@ async def test_positive(mocked_responses):
     assert status is True
     assert data == [
         {
-            "collection": "42",
+            "collection": 42,
             "datetime": "1970-01-01T00:00:00.042000",
-            "entry": "42",
+            "entry": 42,
             "id": "bid/cid",
         }
     ]
@@ -55,8 +55,8 @@ async def test_negative(mocked_responses):
     assert data == [
         {
             "id": "bid/cid",
-            "collection": "123",
-            "entry": "42",
+            "collection": 123,
+            "entry": 42,
             "datetime": "1970-01-01T00:00:00.123000",
         }
     ]


### PR DESCRIPTION
It's very often that I need to check the datetime when a collection was changed. Sometimes I use the notification emails because the timestamps in the `/buckets/monitor/collections/changes` are not human readable.

It would be useful to have human-readable at hand always (from CLI or UI). Hence this changes that returns them always as data, even if the check returns true.