### PR TITLE
Mark sample request in README as http

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Every check defined in your configuration file is exposed as an endpoint that returns `200` if successful or `5XX` otherwise:
 
-```json
+```http
 GET /checks/{a-project}/{a-name}
 
 HTTP/1.1 200 OK


### PR DESCRIPTION
The code sample isn't valid JSON, so it renders with error sections. Marking it as HTTP looks just as good in the JSON section, and better in the HTTP headers section.