### PR TITLE
Move several parts to checks.remotesettings.utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Server configuration is done via environment variables:
 * ``LOG_LEVEL``: One of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL`` (default: ``INFO``)
 * ``LOG_FORMAT``: Set to ``text`` for human-readable logs (default: ``json``)
 * ``VERSION_FILE``: Path to version JSON file (default: ``"version.json"``)
+* ``REQUESTS_TIMEOUT_SECONDS``: Timeout in seconds for HTTP requests (default: ``2``)
+* ``REQUESTS_MAX_RETRIES``: Number of retries for HTTP requests (default: ``4``)
 * ``SENTRY_DSN``: Report errors to the specified Sentry ``"https://<key>@sentry.io/<project>"`` (default: disabled)
 
 

--- a/checks/remotesettings/attachments_availability.py
+++ b/checks/remotesettings/attachments_availability.py
@@ -4,7 +4,7 @@ Timestamps of entries in monitoring endpoint should match collection timestamp.
 import asyncio
 import requests
 
-from kinto_http import Client
+from .utils import KintoClient as Client
 
 
 def get_records(client, bucket, collection, timestamp):
@@ -20,7 +20,6 @@ def test_url(url):
     return False
 
 
-# TODO: should retry requests. cf. lambdas code
 async def run(query, server):
     loop = asyncio.get_event_loop()
 

--- a/checks/remotesettings/changes_timestamps.py
+++ b/checks/remotesettings/changes_timestamps.py
@@ -4,7 +4,7 @@ Timestamps of entries in monitoring endpoint should match collection timestamp.
 import asyncio
 from datetime import datetime
 
-from kinto_http import Client
+from .utils import KintoClient as Client
 
 
 def get_timestamp(client, bucket, collection, timestamp):
@@ -13,7 +13,6 @@ def get_timestamp(client, bucket, collection, timestamp):
     )
 
 
-# TODO: should retry requests. cf. lambdas code
 async def run(query, server):
     loop = asyncio.get_event_loop()
 

--- a/checks/remotesettings/collections_consistency.py
+++ b/checks/remotesettings/collections_consistency.py
@@ -2,10 +2,11 @@
 Preview and final collections have consistent records and status.
 """
 import asyncio
-import copy
 import logging
 
 from kinto_http import Client, BearerTokenAuth
+
+from .utils import fetch_signed_resources
 
 
 logger = logging.getLogger(__name__)
@@ -31,57 +32,6 @@ def compare_collections(a, b):
             diff.append(ra)
     diff.extend(b_by_id.values())
     return diff
-
-
-def fetch_signed_resources(server_url, auth):
-    # List signed collection using capabilities.
-    client = Client(server_url=server_url, auth=auth)
-    info = client.server_info()
-    try:
-        resources = info["capabilities"]["signer"]["resources"]
-    except KeyError:
-        raise ValueError("No signer capabilities found. Run on *writer* server!")
-
-    # Build the list of signed collections, source -> preview -> destination
-    # For most cases, configuration of signed resources is specified by bucket and
-    # does not contain any collection information.
-    resources_by_bid = {}
-    resources_by_cid = {}
-    preview_buckets = set()
-    for resource in resources:
-        bid = resource["destination"]["bucket"]
-        cid = resource["destination"]["collection"]
-        if resource["source"]["collection"] is not None:
-            resources_by_cid[(bid, cid)] = resource
-        else:
-            resources_by_bid[bid] = resource
-        if "preview" in resource:
-            preview_buckets.add(resource["preview"]["bucket"])
-
-    resources = []
-    monitored = client.get_records(
-        bucket="monitor", collection="changes", _sort="bucket,collection"
-    )
-    for entry in monitored:
-        bid = entry["bucket"]
-        cid = entry["collection"]
-
-        # Skip preview collections entries
-        if bid in preview_buckets:
-            continue
-
-        if (bid, cid) in resources_by_cid:
-            r = resources_by_cid[(bid, cid)]
-        elif bid in resources_by_bid:
-            r = copy.deepcopy(resources_by_bid[bid])
-            r["source"]["collection"] = r["destination"]["collection"] = cid
-            if "preview" in r:
-                r["preview"]["collection"] = cid
-        else:
-            raise ValueError(f"Unknown signed collection {bid}/{cid}")
-        resources.append(r)
-
-    return resources
 
 
 def has_inconsistencies(server_url, auth, resource):

--- a/checks/remotesettings/collections_consistency.py
+++ b/checks/remotesettings/collections_consistency.py
@@ -4,9 +4,7 @@ Preview and final collections have consistent records and status.
 import asyncio
 import logging
 
-from kinto_http import Client, BearerTokenAuth
-
-from .utils import fetch_signed_resources
+from .utils import KintoClient as Client, fetch_signed_resources
 
 
 logger = logging.getLogger(__name__)
@@ -89,14 +87,6 @@ def has_inconsistencies(server_url, auth, resource):
 
 
 async def run(query, server, auth):
-    _type = None
-    if " " in auth:
-        # eg, "Bearer ghruhgrwyhg"
-        _type, auth = auth.split(" ", 1)
-    auth = (
-        tuple(auth.split(":", 1)) if ":" in auth else BearerTokenAuth(auth, type=_type)
-    )
-
     loop = asyncio.get_event_loop()
 
     resources = fetch_signed_resources(server, auth)

--- a/checks/remotesettings/signatures_age.py
+++ b/checks/remotesettings/signatures_age.py
@@ -4,9 +4,7 @@ Signatures should be refreshed periodically, keeping their age under a maximum o
 import asyncio
 from datetime import datetime, timezone
 
-from kinto_http import Client, BearerTokenAuth
-
-from .utils import fetch_signed_resources
+from .utils import KintoClient as Client, fetch_signed_resources
 
 
 def utcnow():
@@ -26,17 +24,9 @@ def get_signature_age_hours(client, bucket, collection):
     return age
 
 
-# TODO: should retry requests. cf. lambdas code
 async def run(query, server, auth, max_age):
     max_age = int(query.get("max_age", max_age))
 
-    _type = None
-    if " " in auth:
-        # eg, "Bearer ghruhgrwyhg"
-        _type, auth = auth.split(" ", 1)
-    auth = (
-        tuple(auth.split(":", 1)) if ":" in auth else BearerTokenAuth(auth, type=_type)
-    )
     client = Client(server_url=server, auth=auth)
 
     source_collections = [

--- a/checks/remotesettings/signatures_age.py
+++ b/checks/remotesettings/signatures_age.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 
 from kinto_http import Client, BearerTokenAuth
 
+from .utils import fetch_signed_resources
+
 
 def utcnow():
     # Tiny wrapper, used for mocking in tests.
@@ -24,36 +26,6 @@ def get_signature_age_hours(client, bucket, collection):
     return age
 
 
-def fetch_source_collections(client):
-    # List signed collection using capabilities.
-    info = client.server_info()
-    try:
-        resources = info["capabilities"]["signer"]["resources"]
-    except KeyError:
-        raise ValueError("No signer capabilities found. Run on *writer* server!")
-
-    collections = set()
-    monitored = client.get_records(
-        bucket="monitor", collection="changes", _sort="bucket,collection"
-    )
-    for entry in monitored:
-        bid = entry["bucket"]
-        cid = entry["collection"]
-
-        for resource in resources:
-            dest = resource["destination"]
-            if dest["bucket"] == bid:
-                if dest["collection"] == cid or dest["collection"] is None:
-                    collections.add(
-                        (
-                            resource["source"]["bucket"],
-                            resource["source"]["collection"] or cid,
-                        )
-                    )
-
-    return sorted(collections)
-
-
 # TODO: should retry requests. cf. lambdas code
 async def run(query, server, auth, max_age):
     max_age = int(query.get("max_age", max_age))
@@ -67,15 +39,20 @@ async def run(query, server, auth, max_age):
     )
     client = Client(server_url=server, auth=auth)
 
-    collections = fetch_source_collections(client)
+    source_collections = [
+        (r["source"]["bucket"], r["source"]["collection"])
+        for r in fetch_signed_resources(server, auth)
+    ]
 
     loop = asyncio.get_event_loop()
     futures = [
         loop.run_in_executor(None, get_signature_age_hours, client, bid, cid)
-        for (bid, cid) in collections
+        for (bid, cid) in source_collections
     ]
     results = await asyncio.gather(*futures)
 
-    ages = {f"{bid}/{cid}": age for ((bid, cid), age) in zip(collections, results)}
+    ages = {
+        f"{bid}/{cid}": age for ((bid, cid), age) in zip(source_collections, results)
+    }
     all_good = all([age is not None and age < max_age for age in ages.values()])
     return all_good, ages

--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -1,0 +1,54 @@
+import copy
+
+from kinto_http import Client
+
+
+def fetch_signed_resources(server_url, auth):
+    # List signed collection using capabilities.
+    client = Client(server_url=server_url, auth=auth)
+    info = client.server_info()
+    try:
+        resources = info["capabilities"]["signer"]["resources"]
+    except KeyError:
+        raise ValueError("No signer capabilities found. Run on *writer* server!")
+
+    # Build the list of signed collections, source -> preview -> destination
+    # For most cases, configuration of signed resources is specified by bucket and
+    # does not contain any collection information.
+    resources_by_bid = {}
+    resources_by_cid = {}
+    preview_buckets = set()
+    for resource in resources:
+        bid = resource["destination"]["bucket"]
+        cid = resource["destination"]["collection"]
+        if resource["source"]["collection"] is not None:
+            resources_by_cid[(bid, cid)] = resource
+        else:
+            resources_by_bid[bid] = resource
+        if "preview" in resource:
+            preview_buckets.add(resource["preview"]["bucket"])
+
+    resources = []
+    monitored = client.get_records(
+        bucket="monitor", collection="changes", _sort="bucket,collection"
+    )
+    for entry in monitored:
+        bid = entry["bucket"]
+        cid = entry["collection"]
+
+        # Skip preview collections entries
+        if bid in preview_buckets:
+            continue
+
+        if (bid, cid) in resources_by_cid:
+            r = resources_by_cid[(bid, cid)]
+        elif bid in resources_by_bid:
+            r = copy.deepcopy(resources_by_bid[bid])
+            r["source"]["collection"] = r["destination"]["collection"] = cid
+            if "preview" in r:
+                r["preview"]["collection"] = cid
+        else:
+            raise ValueError(f"Unknown signed collection {bid}/{cid}")
+        resources.append(r)
+
+    return resources

--- a/checks/remotesettings/validate_signatures.py
+++ b/checks/remotesettings/validate_signatures.py
@@ -12,8 +12,9 @@ import requests
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.x509.oid import NameOID
-from kinto_http import Client
 from kinto_signer.serializer import canonical_json
+
+from .utils import KintoClient as Client
 
 
 logger = logging.getLogger(__name__)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -36,3 +36,6 @@ termcolor==1.1.0 \
 aiohttp_cors==0.7.0 \
     --hash=sha256:0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e \
     --hash=sha256:4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d
+backoff==1.8.0 \
+    --hash=sha256:c7187f15339e775aec926dc6e5e42f8a3ad7d3c2b9a6ecae7b535000f70cd838 \
+    --hash=sha256:d340bb6f36d025c04214b8925112d8456970e5f28dda46e4f1133bf5c622cb0a

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -2,11 +2,7 @@ from unittest import mock
 
 import responses
 
-from checks.remotesettings.collections_consistency import (
-    run,
-    fetch_signed_resources,
-    has_inconsistencies,
-)
+from checks.remotesettings.collections_consistency import run, has_inconsistencies
 
 
 FAKE_AUTH = ""
@@ -23,62 +19,6 @@ RESOURCES = [
         "destination": {"bucket": "security", "collection": "blocklist"},
     },
 ]
-
-
-def test_fetch_signed_resources(mocked_responses):
-    server_url = "http://fake.local/v1"
-    mocked_responses.add(
-        responses.GET,
-        server_url + "/",
-        json={
-            "capabilities": {
-                "signer": {
-                    "resources": [
-                        {
-                            "source": {"bucket": "blog-workspace", "collection": None},
-                            "preview": {"bucket": "blog-preview", "collection": None},
-                            "destination": {"bucket": "blog", "collection": None},
-                        },
-                        {
-                            "source": {
-                                "bucket": "security-workspace",
-                                "collection": "blocklist",
-                            },
-                            "destination": {
-                                "bucket": "security",
-                                "collection": "blocklist",
-                            },
-                        },
-                    ]
-                }
-            }
-        },
-    )
-    changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
-        changes_url,
-        json={
-            "data": [
-                {
-                    "id": "abc",
-                    "bucket": "blog",
-                    "collection": "articles",
-                    "last_modified": 42,
-                },
-                {
-                    "id": "def",
-                    "bucket": "security",
-                    "collection": "blocklist",
-                    "last_modified": 41,
-                },
-            ]
-        },
-    )
-
-    resources = fetch_signed_resources(server_url, auth=FAKE_AUTH)
-
-    assert resources == RESOURCES
 
 
 def test_has_inconsistencies_no_preview(mocked_responses):

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -1,0 +1,69 @@
+import responses
+
+from checks.remotesettings.utils import fetch_signed_resources
+
+
+def test_fetch_signed_resources(mocked_responses):
+    server_url = "http://fake.local/v1"
+    mocked_responses.add(
+        responses.GET,
+        server_url + "/",
+        json={
+            "capabilities": {
+                "signer": {
+                    "resources": [
+                        {
+                            "source": {"bucket": "blog-workspace", "collection": None},
+                            "preview": {"bucket": "blog-preview", "collection": None},
+                            "destination": {"bucket": "blog", "collection": None},
+                        },
+                        {
+                            "source": {
+                                "bucket": "security-workspace",
+                                "collection": "blocklist",
+                            },
+                            "destination": {
+                                "bucket": "security",
+                                "collection": "blocklist",
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+    )
+    changes_url = server_url + "/buckets/monitor/collections/changes/records"
+    mocked_responses.add(
+        responses.GET,
+        changes_url,
+        json={
+            "data": [
+                {
+                    "id": "abc",
+                    "bucket": "blog",
+                    "collection": "articles",
+                    "last_modified": 42,
+                },
+                {
+                    "id": "def",
+                    "bucket": "security",
+                    "collection": "blocklist",
+                    "last_modified": 41,
+                },
+            ]
+        },
+    )
+
+    resources = fetch_signed_resources(server_url, auth="")
+
+    assert resources == [
+        {
+            "source": {"bucket": "blog-workspace", "collection": "articles"},
+            "preview": {"bucket": "blog-preview", "collection": "articles"},
+            "destination": {"bucket": "blog", "collection": "articles"},
+        },
+        {
+            "source": {"bucket": "security-workspace", "collection": "blocklist"},
+            "destination": {"bucket": "security", "collection": "blocklist"},
+        },
+    ]


### PR DESCRIPTION
Several checks will have to pull the list of signed resources, move this to a reusable util.

In order to control requests timeout and retries, have a reusable wrapped Kinto client.