### PR TITLE
Unify responses and aioresponses

### DIFF
--- a/tests/checks/core/test_deployed_version.py
+++ b/tests/checks/core/test_deployed_version.py
@@ -1,9 +1,9 @@
 from checks.core.deployed_version import run
 
 
-async def test_positive(mock_aioresponse):
+async def test_positive(mock_aioresponses):
     url = "http://server.local/v1"
-    mock_aioresponse.get(
+    mock_aioresponses.get(
         url + "/__version__",
         status=200,
         payload={
@@ -14,7 +14,7 @@ async def test_positive(mock_aioresponse):
         },
     )
 
-    mock_aioresponse.get(
+    mock_aioresponses.get(
         "https://api.github.com/repos/mozilla-services/kinto-dist/releases",
         status=200,
         payload=[
@@ -39,9 +39,9 @@ async def test_positive(mock_aioresponse):
     assert data == {"latest_tag": "17.1.4", "deployed_version": "17.1.4"}
 
 
-async def test_negative(mock_aioresponse):
+async def test_negative(mock_aioresponses):
     url = "http://server.local/v1"
-    mock_aioresponse.get(
+    mock_aioresponses.get(
         url + "/__version__",
         status=200,
         payload={
@@ -52,7 +52,7 @@ async def test_negative(mock_aioresponse):
         },
     )
 
-    mock_aioresponse.get(
+    mock_aioresponses.get(
         "https://api.github.com/repos/mozilla-services/kinto-dist/releases",
         status=200,
         payload=[

--- a/tests/checks/core/test_heartbeat.py
+++ b/tests/checks/core/test_heartbeat.py
@@ -1,9 +1,9 @@
 from checks.core.heartbeat import run
 
 
-async def test_positive(mock_aioresponse):
+async def test_positive(mock_aioresponses):
     url = "http://server.local/__heartbeat__"
-    mock_aioresponse.get(url, status=200, payload={})
+    mock_aioresponses.get(url, status=200, payload={})
 
     status, data = await run(url)
 
@@ -11,9 +11,9 @@ async def test_positive(mock_aioresponse):
     assert data == {}
 
 
-async def test_negative(mock_aioresponse):
+async def test_negative(mock_aioresponses):
     url = "http://server.local/__heartbeat__"
-    mock_aioresponse.get(url, status=403, payload={})
+    mock_aioresponses.get(url, status=403, payload={})
 
     status, data = await run(url)
 
@@ -21,7 +21,7 @@ async def test_negative(mock_aioresponse):
     assert data == {}
 
 
-async def test_unreachable(mock_aioresponse):
+async def test_unreachable(mock_aioresponses):
     status, data = await run("http://not-mocked")
 
     assert status is False

--- a/tests/checks/normandy/test_remotesettings_recipes.py
+++ b/tests/checks/normandy/test_remotesettings_recipes.py
@@ -44,9 +44,9 @@ REMOTESETTINGS_RECIPE = {
 }
 
 
-async def test_positive(mock_aioresponse):
-    mock_aioresponse.get(NORMANDY_URL, payload=[NORMANDY_RECIPE])
-    mock_aioresponse.get(REMOTESETTINGS_URL, payload={"data": [REMOTESETTINGS_RECIPE]})
+async def test_positive(mock_aioresponses):
+    mock_aioresponses.get(NORMANDY_URL, payload=[NORMANDY_RECIPE])
+    mock_aioresponses.get(REMOTESETTINGS_URL, payload={"data": [REMOTESETTINGS_RECIPE]})
 
     status, data = await run(NORMANDY_SERVER, REMOTESETTINGS_SERVER)
 
@@ -54,9 +54,9 @@ async def test_positive(mock_aioresponse):
     assert data == {"missing": [], "extras": []}
 
 
-async def test_negative(mock_aioresponse):
-    mock_aioresponse.get(NORMANDY_URL, payload=[NORMANDY_RECIPE])
-    mock_aioresponse.get(
+async def test_negative(mock_aioresponses):
+    mock_aioresponses.get(NORMANDY_URL, payload=[NORMANDY_RECIPE])
+    mock_aioresponses.get(
         REMOTESETTINGS_URL,
         payload={"data": [{"id": "42", "recipe": {"id": 42, "name": "Extra"}}]},
     )

--- a/tests/checks/remotesettings/test_attachments_availability.py
+++ b/tests/checks/remotesettings/test_attachments_availability.py
@@ -4,14 +4,14 @@ from checks.remotesettings.attachments_availability import run
 RECORDS_URL = "/buckets/{}/collections/{}/records"
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.get(
+    mock_responses.get(
         server_url + "/",
         json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [
@@ -20,7 +20,7 @@ async def test_positive(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
-    mocked_responses.get(
+    mock_responses.get(
         records_url,
         json={
             "data": [
@@ -30,8 +30,8 @@ async def test_positive(mocked_responses):
             ]
         },
     )
-    mocked_responses.head("http://cdn/file1.jpg")
-    mocked_responses.head("http://cdn/file2.jpg")
+    mock_responses.head("http://cdn/file1.jpg")
+    mock_responses.head("http://cdn/file2.jpg")
 
     status, data = await run(server_url)
 
@@ -39,14 +39,14 @@ async def test_positive(mocked_responses):
     assert data == {"missing": [], "checked": 2}
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.get(
+    mock_responses.get(
         server_url + "/",
         json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [
@@ -55,7 +55,7 @@ async def test_negative(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
-    mocked_responses.get(
+    mock_responses.get(
         records_url,
         json={
             "data": [
@@ -65,7 +65,7 @@ async def test_negative(mocked_responses):
             ]
         },
     )
-    mocked_responses.head("http://cdn/file.jpg")
+    mock_responses.head("http://cdn/file.jpg")
 
     status, data = await run(server_url)
 

--- a/tests/checks/remotesettings/test_attachments_availability.py
+++ b/tests/checks/remotesettings/test_attachments_availability.py
@@ -1,5 +1,3 @@
-import responses
-
 from checks.remotesettings.attachments_availability import run
 
 
@@ -8,14 +6,12 @@ RECORDS_URL = "/buckets/{}/collections/{}/records"
 
 async def test_positive(mocked_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         server_url + "/",
         json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [
@@ -24,8 +20,7 @@ async def test_positive(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         records_url,
         json={
             "data": [
@@ -35,8 +30,8 @@ async def test_positive(mocked_responses):
             ]
         },
     )
-    mocked_responses.add(responses.HEAD, "http://cdn/file1.jpg")
-    mocked_responses.add(responses.HEAD, "http://cdn/file2.jpg")
+    mocked_responses.head("http://cdn/file1.jpg")
+    mocked_responses.head("http://cdn/file2.jpg")
 
     status, data = await run(server_url)
 
@@ -46,14 +41,12 @@ async def test_positive(mocked_responses):
 
 async def test_negative(mocked_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         server_url + "/",
         json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [
@@ -62,8 +55,7 @@ async def test_negative(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         records_url,
         json={
             "data": [
@@ -73,7 +65,7 @@ async def test_negative(mocked_responses):
             ]
         },
     )
-    mocked_responses.add(responses.HEAD, "http://cdn/file.jpg")
+    mocked_responses.head("http://cdn/file.jpg")
 
     status, data = await run(server_url)
 

--- a/tests/checks/remotesettings/test_attachments_availability.py
+++ b/tests/checks/remotesettings/test_attachments_availability.py
@@ -8,12 +8,12 @@ async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     mock_responses.get(
         server_url + "/",
-        json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
+        payload={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]
@@ -22,7 +22,7 @@ async def test_positive(mock_responses):
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
     mock_responses.get(
         records_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "attachment": {"location": "file1.jpg"}},
                 {"id": "efg", "attachment": {"location": "file2.jpg"}},
@@ -43,12 +43,12 @@ async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     mock_responses.get(
         server_url + "/",
-        json={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
+        payload={"capabilities": {"attachments": {"base_url": "http://cdn/"}}},
     )
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]
@@ -57,7 +57,7 @@ async def test_negative(mock_responses):
     records_url = server_url + RECORDS_URL.format("bid", "cid") + "?_expected=42"
     mock_responses.get(
         records_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "attachment": {"location": "file.jpg"}},
                 {"id": "efg", "attachment": {"location": "missing.jpg"}},

--- a/tests/checks/remotesettings/test_backported_records.py
+++ b/tests/checks/remotesettings/test_backported_records.py
@@ -1,5 +1,3 @@
-import responses
-
 from checks.remotesettings.backported_records import run
 
 
@@ -9,11 +7,9 @@ RECORDS_URL = "/buckets/{}/collections/{}/records"
 async def test_positive(mocked_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.add(
-        responses.HEAD, source_url, json={}, headers={"ETag": '"12345"'}
-    )
+    mocked_responses.head(source_url, json={}, headers={"ETag": '"12345"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mocked_responses.add(responses.HEAD, dest_url, json={}, headers={"ETag": '"12345"'})
+    mocked_responses.head(dest_url, json={}, headers={"ETag": '"12345"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1
@@ -26,13 +22,9 @@ async def test_positive(mocked_responses):
 async def test_negative(mocked_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.add(
-        responses.HEAD, source_url, json={}, headers={"ETag": '"1000000"'}
-    )
+    mocked_responses.head(source_url, json={}, headers={"ETag": '"1000000"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mocked_responses.add(
-        responses.HEAD, dest_url, json={}, headers={"ETag": '"2000000"'}
-    )
+    mocked_responses.head(dest_url, json={}, headers={"ETag": '"2000000"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1

--- a/tests/checks/remotesettings/test_backported_records.py
+++ b/tests/checks/remotesettings/test_backported_records.py
@@ -7,9 +7,9 @@ RECORDS_URL = "/buckets/{}/collections/{}/records"
 async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mock_responses.head(source_url, json={}, headers={"ETag": '"12345"'})
+    mock_responses.head(source_url, headers={"ETag": '"12345"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mock_responses.head(dest_url, json={}, headers={"ETag": '"12345"'})
+    mock_responses.head(dest_url, headers={"ETag": '"12345"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1
@@ -22,9 +22,9 @@ async def test_positive(mock_responses):
 async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mock_responses.head(source_url, json={}, headers={"ETag": '"1000000"'})
+    mock_responses.head(source_url, headers={"ETag": '"1000000"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mock_responses.head(dest_url, json={}, headers={"ETag": '"2000000"'})
+    mock_responses.head(dest_url, headers={"ETag": '"2000000"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1

--- a/tests/checks/remotesettings/test_backported_records.py
+++ b/tests/checks/remotesettings/test_backported_records.py
@@ -4,12 +4,12 @@ from checks.remotesettings.backported_records import run
 RECORDS_URL = "/buckets/{}/collections/{}/records"
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.head(source_url, json={}, headers={"ETag": '"12345"'})
+    mock_responses.head(source_url, json={}, headers={"ETag": '"12345"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mocked_responses.head(dest_url, json={}, headers={"ETag": '"12345"'})
+    mock_responses.head(dest_url, json={}, headers={"ETag": '"12345"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1
@@ -19,12 +19,12 @@ async def test_positive(mocked_responses):
     assert data == []
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     source_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.head(source_url, json={}, headers={"ETag": '"1000000"'})
+    mock_responses.head(source_url, json={}, headers={"ETag": '"1000000"'})
     dest_url = server_url + RECORDS_URL.format("other", "cid")
-    mocked_responses.head(dest_url, json={}, headers={"ETag": '"2000000"'})
+    mock_responses.head(dest_url, json={}, headers={"ETag": '"2000000"'})
 
     status, data = await run(
         server_url, backports={"bid/cid": "other/cid"}, max_lag_seconds=1

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -4,10 +4,10 @@ from checks.remotesettings.changes_timestamps import run
 RECORDS_URL = "/buckets/{}/collections/{}/records"
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [
@@ -16,7 +16,7 @@ async def test_positive(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.head(records_url, headers={"ETag": '"42"'})
+    mock_responses.head(records_url, headers={"ETag": '"42"'})
 
     status, data = await run(server_url)
 
@@ -31,10 +31,10 @@ async def test_positive(mocked_responses):
     ]
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [
@@ -43,7 +43,7 @@ async def test_negative(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.head(records_url, headers={"ETag": '"123"'})
+    mock_responses.head(records_url, headers={"ETag": '"123"'})
 
     status, data = await run(server_url)
 

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -1,5 +1,3 @@
-import responses
-
 from checks.remotesettings.changes_timestamps import run
 
 
@@ -9,8 +7,7 @@ RECORDS_URL = "/buckets/{}/collections/{}/records"
 async def test_positive(mocked_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [
@@ -19,7 +16,7 @@ async def test_positive(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.add(responses.HEAD, records_url, headers={"ETag": '"42"'})
+    mocked_responses.head(records_url, headers={"ETag": '"42"'})
 
     status, data = await run(server_url)
 
@@ -37,8 +34,7 @@ async def test_positive(mocked_responses):
 async def test_negative(mocked_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [
@@ -47,7 +43,7 @@ async def test_negative(mocked_responses):
         },
     )
     records_url = server_url + RECORDS_URL.format("bid", "cid")
-    mocked_responses.add(responses.HEAD, records_url, headers={"ETag": '"123"'})
+    mocked_responses.head(records_url, headers={"ETag": '"123"'})
 
     status, data = await run(server_url)
 

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -9,7 +9,7 @@ async def test_positive(mock_responses):
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]
@@ -36,7 +36,7 @@ async def test_negative(mock_responses):
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -21,7 +21,7 @@ RESOURCES = [
 ]
 
 
-def test_has_inconsistencies_no_preview(mocked_responses):
+def test_has_inconsistencies_no_preview(mock_responses):
     server_url = "http://fake.local/v1"
     resource = {
         "source": {"bucket": "security-workspace", "collection": "blocklist"},
@@ -32,18 +32,18 @@ def test_has_inconsistencies_no_preview(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.get(
+    mock_responses.get(
         collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
-    mocked_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, json={"data": records})
 
     assert has_inconsistencies(server_url, FAKE_AUTH, resource) is None
 
 
-def test_has_inconsistencies_unsupported_status(mocked_responses):
+def test_has_inconsistencies_unsupported_status(mock_responses):
     server_url = "http://fake.local/v1"
     resource = {
         "source": {"bucket": "security-workspace", "collection": "blocklist"},
@@ -52,7 +52,7 @@ def test_has_inconsistencies_unsupported_status(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.get(
+    mock_responses.get(
         collection_url, json={"data": {"id": "blocklist", "status": "to-resign"}}
     )
 
@@ -61,7 +61,7 @@ def test_has_inconsistencies_unsupported_status(mocked_responses):
     assert "unexpected status" in result
 
 
-def test_has_inconsistencies_preview_differs(mocked_responses):
+def test_has_inconsistencies_preview_differs(mock_responses):
     server_url = "http://fake.local/v1"
     resource = {
         "source": {"bucket": "security-workspace", "collection": "blocklist"},
@@ -73,13 +73,13 @@ def test_has_inconsistencies_preview_differs(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.get(
+    mock_responses.get(
         collection_url, json={"data": {"id": "blocklist", "status": "to-review"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
-    mocked_responses.get(
+    mock_responses.get(
         records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
@@ -88,7 +88,7 @@ def test_has_inconsistencies_preview_differs(mocked_responses):
     assert "source and preview differ" in result
 
 
-def test_has_inconsistencies_destination_differs(mocked_responses):
+def test_has_inconsistencies_destination_differs(mock_responses):
     server_url = "http://fake.local/v1"
     resource = {
         "source": {"bucket": "security-workspace", "collection": "blocklist"},
@@ -100,15 +100,15 @@ def test_has_inconsistencies_destination_differs(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.get(
+    mock_responses.get(
         collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
-    mocked_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
-    mocked_responses.get(
+    mock_responses.get(
         records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
@@ -117,7 +117,7 @@ def test_has_inconsistencies_destination_differs(mocked_responses):
     assert "source, preview, and/or destination differ" in result
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
 
     module = "checks.remotesettings.collections_consistency"
@@ -130,7 +130,7 @@ async def test_positive(mocked_responses):
     assert data == {}
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
 
     m = "checks.remotesettings.collections_consistency"

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -31,12 +31,12 @@ def test_has_inconsistencies_no_preview(mock_responses):
         "security-workspace", "blocklist"
     )
     mock_responses.get(
-        collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
+        collection_url, payload={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mock_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, payload={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
-    mock_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, payload={"data": records})
 
     assert has_inconsistencies(server_url, FAKE_AUTH, resource) is None
 
@@ -51,7 +51,7 @@ def test_has_inconsistencies_unsupported_status(mock_responses):
         "security-workspace", "blocklist"
     )
     mock_responses.get(
-        collection_url, json={"data": {"id": "blocklist", "status": "to-resign"}}
+        collection_url, payload={"data": {"id": "blocklist", "status": "to-resign"}}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)
@@ -72,13 +72,13 @@ def test_has_inconsistencies_preview_differs(mock_responses):
         "security-workspace", "blocklist"
     )
     mock_responses.get(
-        collection_url, json={"data": {"id": "blocklist", "status": "to-review"}}
+        collection_url, payload={"data": {"id": "blocklist", "status": "to-review"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mock_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, payload={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
     mock_responses.get(
-        records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
+        records_url, payload={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)
@@ -99,15 +99,15 @@ def test_has_inconsistencies_destination_differs(mock_responses):
         "security-workspace", "blocklist"
     )
     mock_responses.get(
-        collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
+        collection_url, payload={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mock_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, payload={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
-    mock_responses.get(records_url, json={"data": records})
+    mock_responses.get(records_url, payload={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
     mock_responses.get(
-        records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
+        records_url, payload={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -32,15 +32,13 @@ def test_has_inconsistencies_no_preview(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.add(
-        responses.GET,
-        collection_url,
-        json={"data": {"id": "blocklist", "status": "signed"}},
+    mocked_responses.get(
+        collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.add(responses.GET, records_url, json={"data": records})
+    mocked_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
-    mocked_responses.add(responses.GET, records_url, json={"data": records})
+    mocked_responses.get(records_url, json={"data": records})
 
     assert has_inconsistencies(server_url, FAKE_AUTH, resource) is None
 
@@ -54,10 +52,8 @@ def test_has_inconsistencies_unsupported_status(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.add(
-        responses.GET,
-        collection_url,
-        json={"data": {"id": "blocklist", "status": "to-resign"}},
+    mocked_responses.get(
+        collection_url, json={"data": {"id": "blocklist", "status": "to-resign"}}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)
@@ -77,18 +73,14 @@ def test_has_inconsistencies_preview_differs(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.add(
-        responses.GET,
-        collection_url,
-        json={"data": {"id": "blocklist", "status": "to-review"}},
+    mocked_responses.get(
+        collection_url, json={"data": {"id": "blocklist", "status": "to-review"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.add(responses.GET, records_url, json={"data": records})
+    mocked_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
-    mocked_responses.add(
-        responses.GET,
-        records_url,
-        json={"data": records + [{"id": "xyz", "last_modified": 40}]},
+    mocked_responses.get(
+        records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)
@@ -108,20 +100,16 @@ def test_has_inconsistencies_destination_differs(mocked_responses):
     collection_url = server_url + COLLECTION_URL.format(
         "security-workspace", "blocklist"
     )
-    mocked_responses.add(
-        responses.GET,
-        collection_url,
-        json={"data": {"id": "blocklist", "status": "signed"}},
+    mocked_responses.get(
+        collection_url, json={"data": {"id": "blocklist", "status": "signed"}}
     )
     records_url = server_url + RECORDS_URL.format("security-workspace", "blocklist")
-    mocked_responses.add(responses.GET, records_url, json={"data": records})
+    mocked_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security-preview", "blocklist")
-    mocked_responses.add(responses.GET, records_url, json={"data": records})
+    mocked_responses.get(records_url, json={"data": records})
     records_url = server_url + RECORDS_URL.format("security", "blocklist")
-    mocked_responses.add(
-        responses.GET,
-        records_url,
-        json={"data": records + [{"id": "xyz", "last_modified": 40}]},
+    mocked_responses.get(
+        records_url, json={"data": records + [{"id": "xyz", "last_modified": 40}]}
     )
 
     result = has_inconsistencies(server_url, FAKE_AUTH, resource)

--- a/tests/checks/remotesettings/test_collections_consistency.py
+++ b/tests/checks/remotesettings/test_collections_consistency.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import responses
-
 from checks.remotesettings.collections_consistency import run, has_inconsistencies
 
 

--- a/tests/checks/remotesettings/test_latest_approvals.py
+++ b/tests/checks/remotesettings/test_latest_approvals.py
@@ -11,14 +11,14 @@ INFOS = [
 ]
 
 
-def test_get_latest_approvals(mocked_responses):
+def test_get_latest_approvals(mock_responses):
     server_url = "http://fake.local/v1"
     history_url = server_url + HISTORY_URL.format("bid")
     query_params = (
         "?resource_name=collection&target.data.id=cid"
         "&target.data.status=to-sign&_sort=-last_modified&_limit=3"
     )
-    mocked_responses.get(
+    mock_responses.get(
         history_url + query_params,
         json={
             "data": [
@@ -56,7 +56,7 @@ def test_get_latest_approvals(mocked_responses):
         "?resource_name=record&collection_id=cid"
         "&gt_target.data.last_modified=0&lt_target.data.last_modified=1567790095111"
     )
-    mocked_responses.get(
+    mock_responses.get(
         history_url + query_params,
         json={"data": [{"id": "r1"}, {"id": "r2"}, {"id": "r3"}]},
     )
@@ -67,7 +67,7 @@ def test_get_latest_approvals(mocked_responses):
     assert infos == INFOS
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     module = "checks.remotesettings.latest_approvals"
     resources = [{"source": {"bucket": "bid", "collection": "cid"}}]

--- a/tests/checks/remotesettings/test_latest_approvals.py
+++ b/tests/checks/remotesettings/test_latest_approvals.py
@@ -20,7 +20,7 @@ def test_get_latest_approvals(mock_responses):
     )
     mock_responses.get(
         history_url + query_params,
-        json={
+        payload={
             "data": [
                 {
                     "id": "0fdeba9f-d83c-4ab2-99f9-d852d6f22cae",
@@ -58,7 +58,7 @@ def test_get_latest_approvals(mock_responses):
     )
     mock_responses.get(
         history_url + query_params,
-        json={"data": [{"id": "r1"}, {"id": "r2"}, {"id": "r3"}]},
+        payload={"data": [{"id": "r1"}, {"id": "r2"}, {"id": "r3"}]},
     )
     client = Client(server_url=server_url)
 

--- a/tests/checks/remotesettings/test_latest_approvals.py
+++ b/tests/checks/remotesettings/test_latest_approvals.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import responses
-
 from checks.remotesettings.utils import KintoClient as Client
 from checks.remotesettings.latest_approvals import run, get_latest_approvals
 
@@ -20,8 +18,7 @@ def test_get_latest_approvals(mocked_responses):
         "?resource_name=collection&target.data.id=cid"
         "&target.data.status=to-sign&_sort=-last_modified&_limit=3"
     )
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         history_url + query_params,
         json={
             "data": [
@@ -59,8 +56,7 @@ def test_get_latest_approvals(mocked_responses):
         "?resource_name=record&collection_id=cid"
         "&gt_target.data.last_modified=0&lt_target.data.last_modified=1567790095111"
     )
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         history_url + query_params,
         json={"data": [{"id": "r1"}, {"id": "r2"}, {"id": "r3"}]},
     )

--- a/tests/checks/remotesettings/test_push_timestamp.py
+++ b/tests/checks/remotesettings/test_push_timestamp.py
@@ -4,9 +4,9 @@ from unittest import mock
 from checks.remotesettings.push_timestamp import run
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     url = "http://server.local/v1/buckets/monitor/collections/changes/records"
-    mocked_responses.head(url, status=200, headers={"ETag": "abc"})
+    mock_responses.head(url, status=200, headers={"ETag": "abc"})
 
     module = "checks.remotesettings.push_timestamp"
     with mock.patch(f"{module}.get_push_timestamp") as mocked:
@@ -22,9 +22,9 @@ async def test_positive(mocked_responses):
     assert data == {"remotesettings": "abc", "push": "abc"}
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     url = "http://server.local/v1/buckets/monitor/collections/changes/records"
-    mocked_responses.head(url, status=200, headers={"ETag": "abc"})
+    mock_responses.head(url, status=200, headers={"ETag": "abc"})
 
     module = "checks.remotesettings.push_timestamp"
     with mock.patch(f"{module}.get_push_timestamp") as mocked:

--- a/tests/checks/remotesettings/test_push_timestamp.py
+++ b/tests/checks/remotesettings/test_push_timestamp.py
@@ -1,14 +1,12 @@
 import asyncio
 from unittest import mock
 
-import responses
-
 from checks.remotesettings.push_timestamp import run
 
 
 async def test_positive(mocked_responses):
     url = "http://server.local/v1/buckets/monitor/collections/changes/records"
-    mocked_responses.add(responses.HEAD, url, status=200, headers={"ETag": "abc"})
+    mocked_responses.head(url, status=200, headers={"ETag": "abc"})
 
     module = "checks.remotesettings.push_timestamp"
     with mock.patch(f"{module}.get_push_timestamp") as mocked:
@@ -26,7 +24,7 @@ async def test_positive(mocked_responses):
 
 async def test_negative(mocked_responses):
     url = "http://server.local/v1/buckets/monitor/collections/changes/records"
-    mocked_responses.add(responses.HEAD, url, status=200, headers={"ETag": "abc"})
+    mocked_responses.head(url, status=200, headers={"ETag": "abc"})
 
     module = "checks.remotesettings.push_timestamp"
     with mock.patch(f"{module}.get_push_timestamp") as mocked:

--- a/tests/checks/remotesettings/test_signatures_age.py
+++ b/tests/checks/remotesettings/test_signatures_age.py
@@ -18,7 +18,7 @@ def test_get_signature_age_hours(mock_responses):
     collection_url = server_url + COLLECTION_URL.format("bid", "cid")
     mock_responses.get(
         collection_url,
-        json={
+        payload={
             "data": {
                 "id": "cid",
                 "last_signature_date": "2019-09-08T15:11:09.142054+00:00",

--- a/tests/checks/remotesettings/test_signatures_age.py
+++ b/tests/checks/remotesettings/test_signatures_age.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import datetime
-import responses
 from kinto_http import Client
 
 from checks.remotesettings.signatures_age import run, get_signature_age_hours
@@ -17,8 +16,7 @@ RESOURCES = [{"source": {"bucket": "bid", "collection": "cid"}}]
 def test_get_signature_age_hours(mocked_responses):
     server_url = "http://fake.local/v1"
     collection_url = server_url + COLLECTION_URL.format("bid", "cid")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         collection_url,
         json={
             "data": {

--- a/tests/checks/remotesettings/test_signatures_age.py
+++ b/tests/checks/remotesettings/test_signatures_age.py
@@ -13,10 +13,10 @@ RECORDS_URL = COLLECTION_URL + "/records"
 RESOURCES = [{"source": {"bucket": "bid", "collection": "cid"}}]
 
 
-def test_get_signature_age_hours(mocked_responses):
+def test_get_signature_age_hours(mock_responses):
     server_url = "http://fake.local/v1"
     collection_url = server_url + COLLECTION_URL.format("bid", "cid")
-    mocked_responses.get(
+    mock_responses.get(
         collection_url,
         json={
             "data": {
@@ -36,7 +36,7 @@ def test_get_signature_age_hours(mocked_responses):
     assert hours == 23
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     module = "checks.remotesettings.signatures_age"
     with mock.patch(f"{module}.fetch_signed_resources", return_value=RESOURCES):
@@ -48,7 +48,7 @@ async def test_positive(mocked_responses):
     assert data == {}
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     with mock.patch(f"{MODULE}.fetch_signed_resources", return_value=RESOURCES):
         with mock.patch(f"{MODULE}.get_signature_age_hours", return_value=5):

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -1,12 +1,9 @@
-import responses
-
 from checks.remotesettings.utils import fetch_signed_resources
 
 
 def test_fetch_signed_resources(mocked_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         server_url + "/",
         json={
             "capabilities": {
@@ -33,8 +30,7 @@ def test_fetch_signed_resources(mocked_responses):
         },
     )
     changes_url = server_url + "/buckets/monitor/collections/changes/records"
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -1,9 +1,9 @@
 from checks.remotesettings.utils import fetch_signed_resources
 
 
-def test_fetch_signed_resources(mocked_responses):
+def test_fetch_signed_resources(mock_responses):
     server_url = "http://fake.local/v1"
-    mocked_responses.get(
+    mock_responses.get(
         server_url + "/",
         json={
             "capabilities": {
@@ -30,7 +30,7 @@ def test_fetch_signed_resources(mocked_responses):
         },
     )
     changes_url = server_url + "/buckets/monitor/collections/changes/records"
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -5,7 +5,7 @@ def test_fetch_signed_resources(mock_responses):
     server_url = "http://fake.local/v1"
     mock_responses.get(
         server_url + "/",
-        json={
+        payload={
             "capabilities": {
                 "signer": {
                     "resources": [
@@ -32,7 +32,7 @@ def test_fetch_signed_resources(mock_responses):
     changes_url = server_url + "/buckets/monitor/collections/changes/records"
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {
                     "id": "abc",

--- a/tests/checks/remotesettings/test_validate_signatures.py
+++ b/tests/checks/remotesettings/test_validate_signatures.py
@@ -9,10 +9,10 @@ from checks.remotesettings.validate_signatures import run, validate_signature
 RECORDS_URL = "/buckets/{}/collections/{}/records"
 
 
-async def test_positive(mocked_responses):
+async def test_positive(mock_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [
@@ -33,10 +33,10 @@ async def test_positive(mocked_responses):
     assert data == {}
 
 
-async def test_negative(mocked_responses):
+async def test_negative(mock_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.get(
+    mock_responses.get(
         changes_url,
         json={
             "data": [

--- a/tests/checks/remotesettings/test_validate_signatures.py
+++ b/tests/checks/remotesettings/test_validate_signatures.py
@@ -14,7 +14,7 @@ async def test_positive(mock_responses):
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]
@@ -38,7 +38,7 @@ async def test_negative(mock_responses):
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
     mock_responses.get(
         changes_url,
-        json={
+        payload={
             "data": [
                 {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
             ]

--- a/tests/checks/remotesettings/test_validate_signatures.py
+++ b/tests/checks/remotesettings/test_validate_signatures.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 import ecdsa
 import pytest
-import responses
 
 from checks.remotesettings.validate_signatures import run, validate_signature
 
@@ -13,8 +12,7 @@ RECORDS_URL = "/buckets/{}/collections/{}/records"
 async def test_positive(mocked_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [
@@ -38,8 +36,7 @@ async def test_positive(mocked_responses):
 async def test_negative(mocked_responses):
     server_url = "http://fake.local/v1"
     changes_url = server_url + RECORDS_URL.format("monitor", "changes")
-    mocked_responses.add(
-        responses.GET,
+    mocked_responses.get(
         changes_url,
         json={
             "data": [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,7 @@ class ResponsesWrapper:
         self.rsps = rsps
 
     def get(self, *args, **kwargs):
+        kwargs["json"] = kwargs.pop("payload", None)
         return self.rsps.add(responses.GET, *args, **kwargs)
 
     def head(self, *args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ async def cli(aiohttp_client, test_config_toml):
 
 
 @pytest.fixture
-def mock_aioresponse(cli):
+def mock_aioresponses(cli):
     test_server = f"http://{cli.host}:{cli.port}"
     with aioresponses(passthrough=[test_server]) as m:
         yield m
@@ -62,6 +62,6 @@ class ResponsesWrapper:
 
 
 @pytest.fixture
-def mocked_responses():
+def mock_responses():
     with responses.RequestsMock() as rsps:
         yield ResponsesWrapper(rsps)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,21 @@ def mock_aioresponse(cli):
         yield m
 
 
+class ResponsesWrapper:
+    """A tiny wrapper to mimic the aioresponses API.
+    """
+
+    def __init__(self, rsps):
+        self.rsps = rsps
+
+    def get(self, *args, **kwargs):
+        return self.rsps.add(responses.GET, *args, **kwargs)
+
+    def head(self, *args, **kwargs):
+        return self.rsps.add(responses.HEAD, *args, **kwargs)
+
+
 @pytest.fixture
 def mocked_responses():
     with responses.RequestsMock() as rsps:
-        yield rsps
+        yield ResponsesWrapper(rsps)

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -68,8 +68,8 @@ async def test_checks(cli):
     ]
 
 
-async def test_check_positive(cli, mock_aioresponse):
-    mock_aioresponse.get(
+async def test_check_positive(cli, mock_aioresponses):
+    mock_aioresponses.get(
         "http://server.local/__heartbeat__", status=200, payload={"ok": True}
     )
 
@@ -86,8 +86,8 @@ async def test_check_positive(cli, mock_aioresponse):
     assert body["data"] == {"ok": True}
 
 
-async def test_check_negative(cli, mock_aioresponse):
-    mock_aioresponse.get("http://server.local/__heartbeat__", status=503)
+async def test_check_negative(cli, mock_aioresponses):
+    mock_aioresponses.get("http://server.local/__heartbeat__", status=503)
 
     response = await cli.get("/checks/testproject/hb")
 
@@ -97,21 +97,21 @@ async def test_check_negative(cli, mock_aioresponse):
     assert body["data"] is None
 
 
-async def test_check_cached(cli, mock_aioresponse):
-    mock_aioresponse.get(
+async def test_check_cached(cli, mock_aioresponses):
+    mock_aioresponses.get(
         "http://server.local/__heartbeat__", status=200, payload={"ok": True}
     )
 
     await cli.get("/checks/testproject/hb")
 
-    mock_aioresponse.clear()
+    mock_aioresponses.clear()
 
     response = await cli.get("/checks/testproject/hb")
 
     assert response.status == 200
 
 
-async def test_check_cached_by_queryparam(cli, mock_aioresponse):
+async def test_check_cached_by_queryparam(cli, mock_aioresponses):
     resp = await cli.get("/checks/testproject/fake")
     dt_no_params = (await resp.json())["datetime"]
 
@@ -136,8 +136,8 @@ async def test_cors_enabled(cli):
     assert "Access-Control-Allow-Origin" in response.headers
 
 
-async def test_sentry_event_on_negative(cli, mock_aioresponse):
-    mock_aioresponse.get("http://server.local/__heartbeat__", status=503)
+async def test_sentry_event_on_negative(cli, mock_aioresponses):
+    mock_aioresponses.get("http://server.local/__heartbeat__", status=503)
 
     with mock.patch("sentry_sdk.hub.Hub.capture_message") as mocked:
         await cli.get("/checks/testproject/hb")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,9 +24,9 @@ def test_run_web(test_config_toml):
     assert mocked.called
 
 
-def test_run_check(mock_aioresponse):
+def test_run_check(mock_aioresponses):
     url = "http://server.local/__heartbeat__"
-    mock_aioresponse.get(url, status=200, payload={"ok": True})
+    mock_aioresponses.get(url, status=200, payload={"ok": True})
 
     assert run_check(
         {


### PR DESCRIPTION
Previously you had to `import responses` to register mock responses because you had to have access to `responses.HEAD` and `responses.GET`. Additionally, it was hard to remember if it was `mock_` or `mocked_` and `response` or `responses`. Harmonize this for `responses` and `aioresponses`.