### PR TITLE
Show full error representation in response

### DIFF
--- a/poucave/middleware.py
+++ b/poucave/middleware.py
@@ -48,5 +48,5 @@ async def error_middleware(request, handler):
     except Exception as e:
         # Unexpected errors are returned as JSON with 500 status.
         logger.exception(e)
-        body = {"success": False, "data": str(e)}
+        body = {"success": False, "data": repr(e)}
         return web.json_response(body, status=web.HTTPInternalServerError.status_code)

--- a/tests/test_app_init.py
+++ b/tests/test_app_init.py
@@ -19,7 +19,7 @@ async def test_json_errors(cli):
         resp = await cli.get("/checks/testproject/hb")
         body = await resp.json()
     assert not body["success"]
-    assert body["data"] == "boom"
+    assert body["data"] == "ValueError('boom')"
 
 
 async def test_404_errors(cli):


### PR DESCRIPTION
For some kind of errors (eg. KeyError), the string representation is not
explicit enough.