### PR TITLE
Only return collections inconsistency in changes_timestamps()

### DIFF
--- a/checks/remotesettings/changes_timestamps.py
+++ b/checks/remotesettings/changes_timestamps.py
@@ -25,19 +25,17 @@ async def run(server: str) -> CheckResult:
     ]
     results = await run_parallel(*futures)
 
-    datetimes = []
+    collections = {}
     for (entry, collection_timestamp) in zip(entries, results):
         entry_timestamp = entry["last_modified"]
         collection_timestamp = int(collection_timestamp)
         dt = datetime.utcfromtimestamp(collection_timestamp / 1000).isoformat()
-        datetimes.append(
-            {
-                "id": "{bucket}/{collection}".format(**entry),
+
+        if entry_timestamp != collection_timestamp:
+            collections["{bucket}/{collection}".format(**entry)] = {
                 "collection": collection_timestamp,
                 "entry": entry_timestamp,
                 "datetime": dt,
             }
-        )
 
-    all_good = all([r["entry"] == r["collection"] for r in datetimes])
-    return all_good, datetimes
+    return len(collections) == 0, collections

--- a/tests/checks/remotesettings/test_changes_timestamps.py
+++ b/tests/checks/remotesettings/test_changes_timestamps.py
@@ -21,14 +21,7 @@ async def test_positive(mock_responses):
     status, data = await run(server_url)
 
     assert status is True
-    assert data == [
-        {
-            "collection": 42,
-            "datetime": "1970-01-01T00:00:00.042000",
-            "entry": 42,
-            "id": "bid/cid",
-        }
-    ]
+    assert data == {}
 
 
 async def test_negative(mock_responses):
@@ -48,11 +41,10 @@ async def test_negative(mock_responses):
     status, data = await run(server_url)
 
     assert status is False
-    assert data == [
-        {
-            "id": "bid/cid",
+    assert data == {
+        "bid/cid": {
             "collection": 123,
             "entry": 42,
             "datetime": "1970-01-01T00:00:00.123000",
         }
-    ]
+    }


### PR DESCRIPTION
In #9 I thought it would make sense to list them all.

But this ends up to be painful to read, if one is different among a long list of values. Plus, we now have `latest_approvals`  #22  which gives the timestamp/approval information.