### PR TITLE
Add check for cloudfront invalidations

### DIFF
--- a/checks/remotesettings/cloudfront_invalidations.py
+++ b/checks/remotesettings/cloudfront_invalidations.py
@@ -1,0 +1,58 @@
+"""
+When changes are approved, the Cloudfront CDN should be invalidated and
+the content of source should match the cache.
+
+The list of failing collections is returned, with the timestamps of source
+and CDN for both the collection metadata and the records.
+"""
+from poucave.typings import CheckResult
+from poucave.utils import run_parallel
+
+from .utils import KintoClient
+
+
+async def fetch_timestamps(client, bucket, collection):
+    metadata = await client.get_collection(bucket=bucket, id=collection)
+    collection_timestamp = metadata["data"]["last_modified"]
+    records_timestamp = await client.get_records_timestamp(
+        bucket=bucket, collection=collection
+    )
+    return collection_timestamp, records_timestamp
+
+
+async def run(server: str, cdn: str) -> CheckResult:
+    source_client = KintoClient(server_url=server)
+    entries = await source_client.get_records(bucket="monitor", collection="changes")
+
+    # Fetch timestamps on source server.
+    source_futures = [
+        fetch_timestamps(
+            source_client, bucket=entry["bucket"], collection=entry["collection"]
+        )
+        for entry in entries
+    ]
+    source_results = await run_parallel(*source_futures)
+
+    # Do exactly the same with CDN.
+    cdn_client = KintoClient(server_url=cdn)
+    cdn_futures = [
+        fetch_timestamps(
+            cdn_client, bucket=entry["bucket"], collection=entry["collection"]
+        )
+        for entry in entries
+    ]
+    cdn_results = await run_parallel(*cdn_futures)
+
+    # Make sure everything matches.
+    collections = {}
+    for entry, source_result, cdn_result in zip(entries, source_results, cdn_results):
+        source_col_ts, source_records_ts = source_result
+        cdn_col_ts, cdn_records_ts = cdn_result
+
+        if source_col_ts != cdn_col_ts or source_records_ts != cdn_records_ts:
+            collections["{bucket}/{collection}".format(**entry)] = {
+                "source": {"collection": source_col_ts, "records": source_records_ts},
+                "cdn": {"collection": cdn_col_ts, "records": cdn_records_ts},
+            }
+
+    return len(collections) == 0, collections

--- a/tests/checks/remotesettings/test_cloudfront_invalidations.py
+++ b/tests/checks/remotesettings/test_cloudfront_invalidations.py
@@ -1,0 +1,71 @@
+from checks.remotesettings.cloudfront_invalidations import run
+
+COLLECTION_URL = "/buckets/{}/collections/{}"
+RECORDS_URL = COLLECTION_URL + "/records"
+
+
+async def test_positive(mock_responses):
+    server_url = "http://fake.local/v1"
+    changes_url = server_url + RECORDS_URL.format("monitor", "changes")
+    mock_responses.get(
+        changes_url,
+        payload={
+            "data": [
+                {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
+            ]
+        },
+    )
+    cdn_url = "http://cdn.local/v1"
+
+    collection_url = COLLECTION_URL.format("bid", "cid")
+    mock_responses.get(
+        server_url + collection_url, payload={"data": {"last_modified": 123}}
+    )
+    mock_responses.get(
+        cdn_url + collection_url, payload={"data": {"last_modified": 123}}
+    )
+
+    records_url = RECORDS_URL.format("bid", "cid")
+    mock_responses.head(server_url + records_url, headers={"ETag": '"42"'})
+    mock_responses.head(cdn_url + records_url, headers={"ETag": '"42"'})
+
+    status, data = await run(server_url, cdn_url)
+
+    assert status is True
+    assert data == {}
+
+
+async def test_negative(mock_responses):
+    server_url = "http://fake.local/v1"
+    changes_url = server_url + RECORDS_URL.format("monitor", "changes")
+    mock_responses.get(
+        changes_url,
+        payload={
+            "data": [
+                {"id": "abc", "bucket": "bid", "collection": "cid", "last_modified": 42}
+            ]
+        },
+    )
+    cdn_url = "http://cdn.local/v1"
+
+    collection_url = COLLECTION_URL.format("bid", "cid")
+    mock_responses.get(
+        server_url + collection_url, payload={"data": {"last_modified": 456}}
+    )
+    mock_responses.get(
+        cdn_url + collection_url, payload={"data": {"last_modified": 123}}
+    )
+
+    records_url = RECORDS_URL.format("bid", "cid")
+    mock_responses.head(server_url + records_url, headers={"ETag": '"40"'})
+    mock_responses.head(cdn_url + records_url, headers={"ETag": '"42"'})
+
+    status, data = await run(server_url, cdn_url)
+
+    assert status is False
+    assert data == {
+        "bid/cid": {
+            "cdn": {"collection": 123, "records": "42"},
+            "source": {"collection": 456, "records": "40"},
+        }
+    }


### PR DESCRIPTION
I expect this check to fail when the CloudFront invalidation fails in kinto-signer