### PR TITLE
Install soupsieve to suppress bs4 warning

### DIFF
--- a/checks/remotesettings/requirements.txt
+++ b/checks/remotesettings/requirements.txt
@@ -82,3 +82,6 @@ Unidecode==1.1.1 \
 six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73
+soupsieve==1.9.4 \
+    --hash=sha256:605f89ad5fdbfefe30cdc293303665eff2d188865d4dbe4eb510bba1edfbfce3 \
+    --hash=sha256:b91d676b330a0ebd5b21719cb6e9b57c57d433671f65b9c28dd3461d9a1ed0b6


### PR DESCRIPTION
We don't use it, but installing this package removes a warning in application startup. I think it's worth it but someone may disagree :)  