### PR TITLE
Fix #170: cached timestamps carry timezone info

### DIFF
--- a/poucave/main.py
+++ b/poucave/main.py
@@ -4,7 +4,7 @@ import importlib
 import json
 import logging.config
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import aiohttp_cors
@@ -112,12 +112,12 @@ class Handlers:
                 last_success = None
             else:
                 timestamp, last_success, _ = result
-                age = (datetime.now() - timestamp).seconds
+                age = (datetime.now(timezone.utc) - timestamp).seconds
 
             if age > ttl:
                 # Execute the check again.
                 success, data = await func(**params)
-                result = datetime.now(), success, data
+                result = datetime.now(timezone.utc), success, data
                 self.cache.set(cache_key, result)
 
                 # If different from last time, then alert on Sentry.

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -1,3 +1,4 @@
+import re
 from unittest import mock
 
 from poucave import config
@@ -79,7 +80,7 @@ async def test_check_positive(cli, mock_aioresponses):
 
     assert response.status == 200
     body = await response.json()
-    assert "datetime" in body
+    assert re.compile("....-..-..T..:..:..\\.......+..:..").match(body["datetime"])
     assert body["success"]
     assert body["project"] == "testproject"
     assert body["name"] == "hb"


### PR DESCRIPTION
Fix #170

This should be enough for timeago to show relative time properly