### PR TITLE
Fix cloudfront age check when age = 0

### DIFF
--- a/checks/core/cloudfront_age.py
+++ b/checks/core/cloudfront_age.py
@@ -14,10 +14,9 @@ async def run(url: str, max_age: str) -> CheckResult:
 
     _, headers = await fetch_head(url)
 
-    if "Age" in headers:
-        age = int(headers["Age"])
-
-    elif "Miss" not in headers.get("X-Cache", ""):
+    if "X-Cache" not in headers:
         raise ValueError("URL does not have CloudFront CDN headers")
+
+    age = int(headers.get("Age", 0))
 
     return age < max_age, age

--- a/tests/checks/core/test_cloudfront_age.py
+++ b/tests/checks/core/test_cloudfront_age.py
@@ -5,7 +5,9 @@ from checks.core.cloudfront_age import run
 
 async def test_positive(mock_aioresponses):
     url = "http://cdn.server/foo"
-    mock_aioresponses.head(url, status=200, headers={"Age": "23"})
+    mock_aioresponses.head(
+        url, status=200, headers={"Age": "23", "X-Cache": "Hit from cloudfront"}
+    )
 
     status, data = await run(url, max_age=30)
 
@@ -15,12 +17,24 @@ async def test_positive(mock_aioresponses):
 
 async def test_negative(mock_aioresponses):
     url = "http://cdn.server/foo"
-    mock_aioresponses.head(url, status=200, headers={"Age": "33"})
+    mock_aioresponses.head(
+        url, status=200, headers={"Age": "33", "X-Cache": "Hit from cloudfront"}
+    )
 
     status, data = await run(url, max_age=30)
 
     assert status is False
     assert data == 33
+
+
+async def test_positive_fresh_hit(mock_aioresponses):
+    url = "http://cdn.server/foo"
+    mock_aioresponses.head(url, status=200, headers={"X-Cache": "Hit from cloudfront"})
+
+    status, data = await run(url, max_age=30)
+
+    assert status is True
+    assert data == 0
 
 
 async def test_positive_miss(mock_aioresponses):


### PR DESCRIPTION
The `Age` header is not returned when Age = 0