### PR TITLE
Return latest approvals of N last days only

### DIFF
--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -136,6 +136,9 @@ async def fetch_signed_resources(server_url: str, auth: str) -> List[Dict[str, D
                 r["preview"]["collection"] = cid
         else:
             raise ValueError(f"Unknown signed collection {bid}/{cid}")
+
+        r["last_modified"] = entry["last_modified"]
+
         resources.append(r)
 
     return resources

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -70,11 +70,13 @@ async def test_fetch_signed_resources(mock_responses):
 
     assert resources == [
         {
+            "last_modified": 42,
             "source": {"bucket": "blog-workspace", "collection": "articles"},
             "preview": {"bucket": "blog-preview", "collection": "articles"},
             "destination": {"bucket": "blog", "collection": "articles"},
         },
         {
+            "last_modified": 41,
             "source": {"bucket": "security-workspace", "collection": "blocklist"},
             "destination": {"bucket": "security", "collection": "blocklist"},
         },


### PR DESCRIPTION
The latest approvals used to take a long time, because it was retrieving history and diffs or every collections. I think it makes sense to limit the range of changes (1 week is enough?)