### PR TITLE
Add lag margin to reported recipes check

### DIFF
--- a/checks/normandy/reported_recipes.py
+++ b/checks/normandy/reported_recipes.py
@@ -6,6 +6,7 @@ The list of recipes for which no event was received is returned. The min/max
 timestamps give the datetime range of the dataset obtained from
 https://sql.telemetry.mozilla.org/queries/64921/
 """
+import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Dict
@@ -22,6 +23,9 @@ NORMANDY_URL = "{server}/api/v1/recipe/signed/?enabled=1"
 RECIPE_URL = "{server}/api/v1/recipe/{id}/"
 
 RFC_3339 = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+logger = logging.getLogger(__name__)
 
 
 async def run(
@@ -57,6 +61,8 @@ async def run(
     min_datetime = datetime.fromisoformat(min_timestamp)
     futures = [fetch_json(RECIPE_URL.format(server=server, id=rid)) for rid in extras]
     results = await run_parallel(*futures)
+    for result in results:
+        logger.debug("Extra recipe {id} modified on {last_updated}".format(**result))
     extras -= set(
         rid
         for rid, details in zip(extras, results)

--- a/checks/normandy/reported_recipes.py
+++ b/checks/normandy/reported_recipes.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 async def run(
-    api_key: str, server: str, min_total_events: int = 1000, lag_margin: int = 3600
+    api_key: str, server: str, min_total_events: int = 1000, lag_margin: int = 600
 ) -> CheckResult:
     # Fetch latest results from Redash JSON API.
     rows = await fetch_redash(REDASH_QUERY_ID, api_key)
@@ -63,6 +63,9 @@ async def run(
     results = await run_parallel(*futures)
     for result in results:
         logger.debug("Extra recipe {id} modified on {last_updated}".format(**result))
+    # We add a lag margin, because modified recipes take some time to reach the
+    # clients. According to current figures obtained from uptake telemetry,
+    # 95% of them obtain the changes in less than ~5min (hence default of 10min).
     extras -= set(
         rid
         for rid, details in zip(extras, results)

--- a/tests/checks/normandy/test_reported_recipes.py
+++ b/tests/checks/normandy/test_reported_recipes.py
@@ -84,7 +84,7 @@ async def test_negative_min_events(mock_aioresponses):
     )
     mock_aioresponses.get(
         RECIPE_URL.format(server=NORMANDY_SERVER, id="111"),
-        payload={"last_updated": "2019-09-14T00:36:12.348Z"},
+        payload={"id": 111, "last_updated": "2019-09-14T00:36:12.348Z"},
     )
 
     with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):
@@ -108,7 +108,7 @@ async def test_positive_ignore_recents(mock_aioresponses):
     )
     mock_aioresponses.get(
         RECIPE_URL.format(server=NORMANDY_SERVER, id="111"),
-        payload={"last_updated": "2019-09-16T02:36:12.348Z"},
+        payload={"id": 111, "last_updated": "2019-09-16T02:36:12.348Z"},
     )
 
     with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):


### PR DESCRIPTION
I don't know if it's the right approach, or if we should dig more into the client submission timestamp thing, but this seems necessary anyway.

(Note: the lag for push notification is less than ~5minutes for 95% of clients, see https://delivery-checks.prod.mozaws.net/checks/remotesettings-uptake/max-age)