### PR TITLE
add tip for spotting which check is failing in a tag group

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ make tests
 ## Showing status of a group of checks
 
 ```
-$ curl -s https://poucave.host/checks/tags/my-tag | jq -r  '.[] | "\(.project):\(.name) \(.success)"' | column -t
+$ curl -s https://poucave.host/checks/tags/my-tag | jq -r  '.[] | "\(.project) \(.name) \(.success)"' | column -t
 
-projectA:heartbeat		true 
-projectB:heartbeat		false 
-projectC:heartbeat		true 
+projectA    heartbeat    true
+projectB    some-check   false
+projectC    heartbeat    true
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,19 @@ make check project=myproject check=mycheck
 make tests
 ```
 
+# Tips
+
+## Showing status of a group of checks
+
+```
+$ curl -s https://poucave.host/checks/tags/my-tag | jq -r  '.[] | "\(.project):\(.name) \(.success)"' | column -t
+
+projectA:heartbeat		true 
+projectB:heartbeat		false 
+projectC:heartbeat		true 
+...
+```
+
 ## License
 
 *Poucave* is licensed under the MPLv2. See the `LICENSE` file for details.


### PR DESCRIPTION
Create a new tips section in the README and added a tip for tags