### PR TITLE
Fix #227: compute error rate over periods of 10 minutes

### DIFF
--- a/checks/normandy/uptake_error_rate.py
+++ b/checks/normandy/uptake_error_rate.py
@@ -1,13 +1,13 @@
 """
 The percentage of reported errors in Uptake Telemetry should be under the specified
-maximum.
+maximum. Error rate is computed for each period of 10min.
 
 For each recipe whose error rate is above the maximum, the total number of events
 for each status is returned. The min/max timestamps give the datetime range of the
-dataset obtained from https://sql.telemetry.mozilla.org/queries/64921/
+dataset obtained from https://sql.telemetry.mozilla.org/queries/67658/
 """
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from poucave.typings import CheckResult
 from poucave.utils import fetch_redash
@@ -15,7 +15,7 @@ from poucave.utils import fetch_redash
 
 EXPOSED_PARAMETERS = ["max_error_percentage", "min_total_events"]
 
-REDASH_QUERY_ID = 64921
+REDASH_QUERY_ID = 67658
 
 # Normandy uses the Uptake telemetry statuses in a specific way.
 # See https://searchfox.org/mozilla-central/rev/4218cb868d8deed13e902718ba2595d85e12b86b/toolkit/components/normandy/lib/Uptake.jsm#23-43
@@ -37,7 +37,7 @@ def sort_dict_desc(d, key):
 async def run(
     api_key: str,
     max_error_percentage: float,
-    min_total_events: int = 100,
+    min_total_events: int = 20,
     ignore_status: List[str] = [],
 ) -> CheckResult:
     # Ignored statuses are specified using the Normandy ones.
@@ -49,46 +49,71 @@ async def run(
     min_timestamp = min(r["min_timestamp"] for r in rows)
     max_timestamp = max(r["max_timestamp"] for r in rows)
 
-    by_collection: Dict[str, Dict[str, int]] = defaultdict(dict)
+    # We will store reported events by period, by collection,
+    # by version, and by status.
+    # {
+    #   ('2020-01-17T07:50:00', '2020-01-17T08:00:00'): {
+    #     '113': {
+    #       'success': 4699,
+    #       'sync_error': 39
+    #     },
+    #     ...
+    #   }
+    # }
+    periods: Dict[Tuple[str, str], Dict] = {}
     for row in rows:
+        period: Tuple[str, str] = (row["min_timestamp"], row["max_timestamp"])
+        if period not in periods:
+            by_collection: Dict[str, Dict[str, int]] = defaultdict(dict)
+            periods[period] = by_collection
+
         rid = int(row["source"].split("/")[-1])
         # In Firefox 67, `custom_2_error` was used instead of `backoff`.
         status = row["status"].replace("custom_2_error", "backoff")
-        by_collection[rid].setdefault(status, 0)
-        by_collection[rid][status] += row["total"]
+        periods[period][rid].setdefault(status, 0)
+        periods[period][rid][status] += row["total"]
 
-    error_rates = {}
-    for rid, all_statuses in by_collection.items():
-        total_statuses = sum(total for status, total in all_statuses.items())
+    error_rates: Dict[str, Dict] = {}
+    for (min_period, max_period), by_collection in periods.items():
+        # Compute error rate by period.
+        # This allows us to prevent error rate to be "spread" over the overall datetime
+        # range of events (eg. a spike of errors during 10min over 2H).
+        for rid, all_statuses in by_collection.items():
+            total_statuses = sum(total for status, total in all_statuses.items())
 
-        # Ignore uptake Telemetry of a certain recipe if the total of collected
-        # events is too small.
-        if total_statuses < min_total_events:
-            continue
+            # Ignore uptake Telemetry of a certain recipe if the total of collected
+            # events is too small.
+            if total_statuses < min_total_events:
+                continue
 
-        statuses = {
-            NORMANDY_STATUSES.get(status, status): total
-            for status, total in all_statuses.items()
-            if status not in ignored_status
-        }
-        ignored = {
-            NORMANDY_STATUSES.get(status, status): total
-            for status, total in all_statuses.items()
-            if status in ignored_status
-        }
-        total_errors = sum(
-            total for status, total in statuses.items() if status.endswith("_error")
-        )
-        error_rate = round(total_errors * 100 / total_statuses, 2)
+            statuses = {
+                NORMANDY_STATUSES.get(status, status): total
+                for status, total in all_statuses.items()
+                if status not in ignored_status
+            }
+            ignored = {
+                NORMANDY_STATUSES.get(status, status): total
+                for status, total in all_statuses.items()
+                if status in ignored_status
+            }
+            total_errors = sum(
+                total for status, total in statuses.items() if status.endswith("_error")
+            )
+            error_rate = round(total_errors * 100 / total_statuses, 2)
 
-        if error_rate < max_error_percentage:
-            continue
+            # If error rate for this period is below threshold, or lower than one reported
+            # in another period, then we ignore it.
+            other_period_rate = error_rates.get(rid, {"error_rate": 0.0})["error_rate"]
+            if error_rate < max_error_percentage or error_rate < other_period_rate:
+                continue
 
-        error_rates[rid] = {
-            "error_rate": error_rate,
-            "statuses": sort_dict_desc(statuses, key=lambda item: item[1]),
-            "ignored": sort_dict_desc(ignored, key=lambda item: item[1]),
-        }
+            error_rates[rid] = {
+                "error_rate": error_rate,
+                "statuses": sort_dict_desc(statuses, key=lambda item: item[1]),
+                "ignored": sort_dict_desc(ignored, key=lambda item: item[1]),
+                "min_timestamp": min_period,
+                "max_timestamp": max_period,
+            }
 
     sort_by_rate = sort_dict_desc(error_rates, key=lambda item: item[1]["error_rate"])
 
@@ -109,11 +134,14 @@ async def run(
           },
           "ignored": {
             "recipe_didnt_match_filter": 5
-          }
-        }
+          },
+          "min_timestamp": "2020-01-17T08:10:00",
+          "max_timestamp": "2020-01-17T08:20:00",
+        },
+        ...
       },
-      "min_timestamp": "2019-09-19T03:47:42.773",
-      "max_timestamp": "2019-09-19T09:43:26.083"
+      "min_timestamp": "2020-01-17T08:00:00",
+      "max_timestamp": "2020-01-17T10:00:00"
     }
     """
     return len(sort_by_rate) == 0, data

--- a/checks/remotesettings/uptake_error_rate.py
+++ b/checks/remotesettings/uptake_error_rate.py
@@ -55,7 +55,6 @@ async def run(
     #     ...
     #   }
     # }
-
     periods: Dict[Tuple[str, str], Dict] = {}
     for row in rows:
         period: Tuple[str, str] = (row["min_timestamp"], row["max_timestamp"])
@@ -135,11 +134,14 @@ async def run(
           },
           "ignored": {
             "network_error": 10476
-          }
-        }
+          },
+          "min_timestamp": "2020-01-17T08:10:00",
+          "max_timestamp": "2020-01-17T08:20:00",
+        },
+        ...
       },
-      "min_timestamp": "2019-09-16T03:40:57.894",
-      "max_timestamp": "2019-09-16T09:34:07.163"
+      "min_timestamp": "2020-01-17T08:00:00",
+      "max_timestamp": "2020-01-17T10:00:00"
     }
     """
     return len(sort_by_rate) == 0, data

--- a/checks/remotesettings/uptake_error_rate.py
+++ b/checks/remotesettings/uptake_error_rate.py
@@ -1,13 +1,13 @@
 """
 The percentage of reported errors in Uptake Telemetry should be under the specified
-maximum.
+maximum. Error rate is computed for each period of 10min.
 
 For each source whose error rate is above the maximum, the total number of events
 for each status is returned. The min/max timestamps give the datetime range of the
-dataset obtained from https://sql.telemetry.mozilla.org/queries/64808/
+dataset obtained from https://sql.telemetry.mozilla.org/queries/67605/
 """
 from collections import defaultdict
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from poucave.typings import CheckResult
 from poucave.utils import fetch_redash
@@ -20,7 +20,7 @@ EXPOSED_PARAMETERS = [
     "ignore_versions",
 ]
 
-REDASH_QUERY_ID = 65039
+REDASH_QUERY_ID = 67605
 
 
 def sort_dict_desc(d, key):
@@ -30,7 +30,7 @@ def sort_dict_desc(d, key):
 async def run(
     api_key: str,
     max_error_percentage: float,
-    min_total_events: int = 10000,
+    min_total_events: int = 1000,
     sources: List[str] = [],
     ignore_status: List[str] = [],
     ignore_versions: List[int] = [],
@@ -41,47 +41,79 @@ async def run(
     min_timestamp = min(r["min_timestamp"] for r in rows)
     max_timestamp = max(r["max_timestamp"] for r in rows)
 
-    by_collection: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
-        lambda: defaultdict(dict)
-    )
+    # We will store reported events by period, by collection,
+    # by version, and by status.
+    # {
+    #   ('2020-01-17T07:50:00', '2020-01-17T08:00:00'): {
+    #     'settings-sync': {
+    #       '71': {
+    #         'success': 4699,
+    #         'sync_error': 39
+    #       },
+    #       ...
+    #     },
+    #     ...
+    #   }
+    # }
+
+    periods: Dict[Tuple[str, str], Dict] = {}
     for row in rows:
+        period: Tuple[str, str] = (row["min_timestamp"], row["max_timestamp"])
+        if period not in periods:
+            by_collection: Dict[str, Dict[str, Dict[str, int]]] = defaultdict(
+                lambda: defaultdict(dict)
+            )
+            periods[period] = by_collection
+
         if len(sources) == 0 or row["source"] in sources:
-            by_collection[row["source"]][row["version"]][row["status"]] = row["total"]
+            periods[period][row["source"]][row["version"]][row["status"]] = row["total"]
 
-    error_rates = {}
-    for cid, all_versions in by_collection.items():
-        total_statuses = 0
-        statuses: Dict[str, int] = defaultdict(int)
-        ignored: Dict[str, int] = defaultdict(int)
+    error_rates: Dict[str, Dict] = {}
+    for (min_period, max_period), by_collection in periods.items():
+        # Compute error rate by period.
+        # This allows us to prevent error rate to be "spread" over the overall datetime
+        # range of events (eg. a spike of errors during 10min over 2H).
+        for cid, all_versions in by_collection.items():
+            total_statuses = 0
+            # Store total by status (which are not ignored).
+            statuses: Dict[str, int] = defaultdict(int)
+            ignored: Dict[str, int] = defaultdict(int)
 
-        for version, all_statuses in all_versions.items():
-            for status, total in all_statuses.items():
-                total_statuses += total
-                if status in ignore_status or int(version) in ignore_versions:
-                    ignored[status] += total
-                else:
-                    statuses[status] += total
+            for version, all_statuses in all_versions.items():
+                for status, total in all_statuses.items():
+                    total_statuses += total
+                    if status in ignore_status or int(version) in ignore_versions:
+                        ignored[status] += total
+                    else:
+                        statuses[status] += total
 
-        # Ignore uptake Telemetry of a certain collection if the total of collected
-        # events is too small.
-        if total_statuses < min_total_events:
-            continue
+            # Ignore uptake Telemetry of a certain collection if the total of collected
+            # events is too small.
+            if total_statuses < min_total_events:
+                continue
 
-        total_errors = sum(
-            total for status, total in statuses.items() if status.endswith("_error")
+            total_errors = sum(
+                total for status, total in statuses.items() if status.endswith("_error")
+            )
+            error_rate = round(total_errors * 100 / total_statuses, 2)
+
+            # If error rate for this period is below threshold, or lower than one reported
+            # in another period, then we ignore it.
+            other_period_rate = error_rates.get(cid, {"error_rate": 0.0})["error_rate"]
+            if error_rate < max_error_percentage or error_rate < other_period_rate:
+                continue
+
+            error_rates[cid] = {
+                "error_rate": error_rate,
+                "statuses": sort_dict_desc(statuses, key=lambda item: item[1]),
+                "ignored": sort_dict_desc(ignored, key=lambda item: item[1]),
+                "min_timestamp": min_period,
+                "max_timestamp": max_period,
+            }
+
+        sort_by_rate = sort_dict_desc(
+            error_rates, key=lambda item: item[1]["error_rate"]
         )
-        error_rate = round(total_errors * 100 / total_statuses, 2)
-
-        if error_rate < max_error_percentage:
-            continue
-
-        error_rates[cid] = {
-            "error_rate": error_rate,
-            "statuses": sort_dict_desc(statuses, key=lambda item: item[1]),
-            "ignored": sort_dict_desc(ignored, key=lambda item: item[1]),
-        }
-
-    sort_by_rate = sort_dict_desc(error_rates, key=lambda item: item[1]["error_rate"])
 
     data = {
         "sources": sort_by_rate,

--- a/tests/checks/normandy/test_normandy_uptake_error_rate.py
+++ b/tests/checks/normandy/test_normandy_uptake_error_rate.py
@@ -6,32 +6,46 @@ MODULE = "checks.normandy.uptake_error_rate"
 
 FAKE_ROWS = [
     {
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T00:40:00",
         "status": "success",
         "source": "normandy/recipe/123",
         "total": 20000,
-        "min_timestamp": "2019-09-16T02:36:12.348",
-        "max_timestamp": "2019-09-16T06:24:58.741",
     },
     {
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T00:40:00",
         "status": "apply_error",
         "source": "normandy/recipe/123",
         "total": 15000,
-        "min_timestamp": "2019-09-16T03:36:12.348",
-        "max_timestamp": "2019-09-16T05:24:58.741",
     },
     {
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T00:40:00",
         "status": "backoff",
         "source": "normandy/recipe/123",
         "total": 4000,
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
     },
     {
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T00:40:00",
         "status": "custom_2_error",
         "source": "normandy/recipe/123",
         "total": 1000,
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+    },
+    {
+        "min_timestamp": "2019-09-16T00:50:00",
+        "max_timestamp": "2019-09-16T01:00:00",
+        "status": "success",
+        "source": "normandy/recipe/123",
+        "total": 1000,
+    },
+    {
+        "min_timestamp": "2019-09-16T00:50:00",
+        "max_timestamp": "2019-09-16T01:00:00",
+        "status": "apply_error",
+        "source": "normandy/recipe/123",
+        "total": 500,
     },
 ]
 
@@ -43,8 +57,8 @@ async def test_positive():
     assert status is True
     assert data == {
         "recipes": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T01:00:00",
     }
 
 
@@ -63,10 +77,12 @@ async def test_negative():
                     "recipe_didnt_match_filter": 5000,
                 },
                 "ignored": {},
+                "min_timestamp": "2019-09-16T00:30:00",
+                "max_timestamp": "2019-09-16T00:40:00",
             }
         },
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T01:00:00",
     }
 
 
@@ -81,8 +97,8 @@ async def test_ignore_status():
     assert status is True
     assert data == {
         "recipes": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T01:00:00",
     }
 
 
@@ -95,6 +111,6 @@ async def test_min_total_events():
     assert status is True
     assert data == {
         "recipes": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2019-09-16T00:30:00",
+        "max_timestamp": "2019-09-16T01:00:00",
     }

--- a/tests/checks/remotesettings/test_uptake_error_rate.py
+++ b/tests/checks/remotesettings/test_uptake_error_rate.py
@@ -6,36 +6,52 @@ MODULE = "checks.remotesettings.uptake_error_rate"
 
 FAKE_ROWS = [
     {
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:20:00",
         "status": "success",
         "source": "blocklists/addons",
         "version": "68",
         "total": 10000,
-        "min_timestamp": "2019-09-16T02:36:12.348",
-        "max_timestamp": "2019-09-16T06:24:58.741",
     },
     {
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:20:00",
         "status": "success",
         "source": "blocklists/addons",
         "version": "67",
         "total": 10000,
-        "min_timestamp": "2019-09-16T02:36:12.348",
-        "max_timestamp": "2019-09-16T06:24:58.741",
     },
     {
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:20:00",
         "status": "up_to_date",
         "source": "blocklists/addons",
         "version": "70",
         "total": 15000,
-        "min_timestamp": "2019-09-16T03:36:12.348",
-        "max_timestamp": "2019-09-16T05:24:58.741",
     },
     {
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:20:00",
         "status": "network_error",
         "source": "blocklists/addons",
         "version": "71",
         "total": 5000,
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+    },
+    {
+        "min_timestamp": "2020-01-17T08:20:00",
+        "max_timestamp": "2020-01-17T08:30:00",
+        "status": "success",
+        "source": "blocklists/addons",
+        "version": "73",
+        "total": 2000,
+    },
+    {
+        "min_timestamp": "2020-01-17T08:20:00",
+        "max_timestamp": "2020-01-17T08:30:00",
+        "status": "custom_1_error",
+        "source": "blocklists/addons",
+        "version": "73",
+        "total": 50,
     },
 ]
 
@@ -47,8 +63,8 @@ async def test_positive():
     assert status is True
     assert data == {
         "sources": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }
 
 
@@ -67,24 +83,28 @@ async def test_negative():
                     "network_error": 5000,
                 },
                 "ignored": {},
+                "min_timestamp": "2020-01-17T08:10:00",
+                "max_timestamp": "2020-01-17T08:20:00",
             }
         },
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }
 
 
 async def test_ignore_status():
     with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):
         status, data = await run(
-            api_key="", max_error_percentage=0.1, ignore_status=["network_error"]
+            api_key="",
+            max_error_percentage=0.1,
+            ignore_status=["network_error", "custom_1_error"],
         )
 
     assert status is True
     assert data == {
         "sources": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }
 
 
@@ -105,10 +125,12 @@ async def test_ignore_version():
                     "success": 10000,
                     "up_to_date": 15000,
                 },
+                "min_timestamp": "2020-01-17T08:10:00",
+                "max_timestamp": "2020-01-17T08:20:00",
             }
         },
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }
 
 
@@ -121,20 +143,20 @@ async def test_min_total_events():
     assert status is True
     assert data == {
         "sources": {},
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }
 
 
 async def test_filter_sources():
     fake_rows = FAKE_ROWS + [
         {
+            "min_timestamp": "2020-01-17T08:10:00",
+            "max_timestamp": "2020-01-17T08:20:00",
             "status": "sync_error",
             "source": "settings-sync",
             "version": "71",
             "total": 50000,
-            "min_timestamp": "2019-09-16T01:36:12.348",
-            "max_timestamp": "2019-09-16T07:24:58.741",
         },
     ]
     with patch_async(f"{MODULE}.fetch_redash", return_value=fake_rows):
@@ -149,8 +171,10 @@ async def test_filter_sources():
                 "error_rate": 100.0,
                 "ignored": {},
                 "statuses": {"sync_error": 50000},
+                "min_timestamp": "2020-01-17T08:10:00",
+                "max_timestamp": "2020-01-17T08:20:00",
             }
         },
-        "min_timestamp": "2019-09-16T01:36:12.348",
-        "max_timestamp": "2019-09-16T07:24:58.741",
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
     }


### PR DESCRIPTION
Fix #227

The query returns a range of 2H. Instead of computing the error rate as an average over these 2H, it computes the error rate over periods of 10 minutes...

The query is refreshed every hour (scans ~5GB of data, at $5 per TB, 2cts per run, 15$/month)