### PR TITLE
Ignore uptake status on a particular version

### DIFF
--- a/tests/checks/remotesettings/test_uptake_error_rate.py
+++ b/tests/checks/remotesettings/test_uptake_error_rate.py
@@ -34,8 +34,16 @@ FAKE_ROWS = [
         "max_timestamp": "2020-01-17T08:20:00",
         "status": "network_error",
         "source": "blocklists/addons",
+        "version": "70",
+        "total": 2500,
+    },
+    {
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:20:00",
+        "status": "network_error",
+        "source": "blocklists/addons",
         "version": "71",
-        "total": 5000,
+        "total": 2500,
     },
     {
         "min_timestamp": "2020-01-17T08:20:00",
@@ -103,6 +111,32 @@ async def test_ignore_status():
     assert status is True
     assert data == {
         "sources": {},
+        "min_timestamp": "2020-01-17T08:10:00",
+        "max_timestamp": "2020-01-17T08:30:00",
+    }
+
+
+async def test_ignore_status_on_version():
+    with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):
+        status, data = await run(
+            api_key="", max_error_percentage=0.1, ignore_status=["network_error@70"],
+        )
+
+    assert status is False
+    assert data == {
+        "sources": {
+            "blocklists/addons": {
+                "error_rate": 6.25,
+                "ignored": {"network_error": 2500},
+                "max_timestamp": "2020-01-17T08:20:00",
+                "min_timestamp": "2020-01-17T08:10:00",
+                "statuses": {
+                    "network_error": 2500,
+                    "success": 20000,
+                    "up_to_date": 15000,
+                },
+            }
+        },
         "min_timestamp": "2020-01-17T08:10:00",
         "max_timestamp": "2020-01-17T08:30:00",
     }


### PR DESCRIPTION
This will allow us to ignore `parse_error`s on 68. 

Should we specify the collection too? 
I was wondering what could be the syntax so I gave up :smirk: ...
```toml
ignore_status = ["security-state/intermediates:parse_error@68"]
```