### PR TITLE
Add status parameter to heartbeat check

### DIFF
--- a/checks/core/heartbeat.py
+++ b/checks/core/heartbeat.py
@@ -9,15 +9,15 @@ from poucave.typings import CheckResult
 from poucave.utils import ClientSession, retry_decorator
 
 
-EXPOSED_PARAMETERS = ["url", "status"]
+EXPOSED_PARAMETERS = ["url", "expected_status"]
 
 
 @retry_decorator
-async def run(url: str, status: int = 200) -> CheckResult:
+async def run(url: str, expected_status: int = 200) -> CheckResult:
     async with ClientSession() as session:
         try:
             async with session.get(url) as response:
-                status = response.status == status
-                return status, await response.json()
+                success = response.status == expected_status
+                return success, await response.json()
         except aiohttp.client_exceptions.ClientError as e:
             return False, str(e)

--- a/checks/core/heartbeat.py
+++ b/checks/core/heartbeat.py
@@ -18,6 +18,10 @@ async def run(url: str, expected_status: int = 200) -> CheckResult:
         try:
             async with session.get(url) as response:
                 success = response.status == expected_status
-                return success, await response.json()
+                if "application/json" in response.headers["Content-Type"]:
+                    data = await response.json()
+                else:
+                    data = await response.text()
+                return success, data
         except aiohttp.client_exceptions.ClientError as e:
             return False, str(e)

--- a/checks/core/heartbeat.py
+++ b/checks/core/heartbeat.py
@@ -9,15 +9,15 @@ from poucave.typings import CheckResult
 from poucave.utils import ClientSession, retry_decorator
 
 
-EXPOSED_PARAMETERS = ["url"]
+EXPOSED_PARAMETERS = ["url", "status"]
 
 
 @retry_decorator
-async def run(url: str) -> CheckResult:
+async def run(url: str, status: int = 200) -> CheckResult:
     async with ClientSession() as session:
         try:
             async with session.get(url) as response:
-                status = response.status == 200
+                status = response.status == status
                 return status, await response.json()
         except aiohttp.client_exceptions.ClientError as e:
             return False, str(e)

--- a/tests/checks/core/test_heartbeat.py
+++ b/tests/checks/core/test_heartbeat.py
@@ -26,3 +26,16 @@ async def test_unreachable(mock_aioresponses):
 
     assert status is False
     assert data == "Connection refused: GET http://not-mocked"
+
+
+async def test_xml_response(mock_aioresponses):
+    url = "http://some.cdn/chains/"
+    some_xml = '<?xml version="1.0"?>\n<Error><Code>AccessDenied</Code></Error>'
+    mock_aioresponses.get(
+        url, status=403, body=some_xml, content_type="application/xml"
+    )
+
+    status, data = await run(url, expected_status=403)
+
+    assert data == some_xml
+    assert status is True


### PR DESCRIPTION
This would allow us to have a check for the CDN which returns 403 on its root URL