### PR TITLE
Allow to check all checks from CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ serve: $(INSTALL_STAMP) $(VERSION_FILE) $(CONFIG_FILE)
 	PYTHONPATH=. $(PYTHON) $(NAME)
 
 check: $(INSTALL_STAMP) $(CONFIG_FILE)
-	PYTHONPATH=. LOG_LEVEL=DEBUG LOG_FORMAT=text $(PYTHON) $(NAME) $(project) $(check)
+	PYTHONPATH=. LOG_LEVEL=DEBUG LOG_FORMAT=text $(PYTHON) $(NAME) check $(project) $(check)
 
 tests: $(INSTALL_STAMP) $(VERSION_FILE)
 	PYTHONPATH=. $(VENV)/bin/pytest tests --cov-report term-missing --cov-fail-under 100 --cov poucave --cov checks

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Set the ``id`` attribute of relevant element to ``${project}--${name}`` (eg. ``r
 Using Docker, and a local config file:
 
 ```
+docker run -v `pwd`/config.toml:/app/config.toml mozilla/poucave check
+
 docker run -v `pwd`/config.toml:/app/config.toml mozilla/poucave check myproject
 
 docker run -v `pwd`/config.toml:/app/config.toml mozilla/poucave check myproject mycheck
@@ -142,10 +144,19 @@ docker run -v `pwd`/config.toml:/app/config.toml mozilla/poucave check myproject
 Or from source:
 
 ```
+make check
+
 make check project=myproject
 
 make check project=myproject check=mycheck
 ```
+
+Return codes:
+
+- `0`: all checks were successful
+- `1`: some check failed
+- `2`: some check crashed (ie. Python exception)
+
 
 ## Tests
 

--- a/poucave/app.py
+++ b/poucave/app.py
@@ -332,12 +332,13 @@ def main(argv):
     checks = Checks.from_conf(conf)
 
     # If CLI arg is provided, run the check.
-    if len(argv) >= 1:
-        project = argv[0]
+    if len(argv) >= 1 and argv[0] == "check":
+        project = None
         name = None
         if len(argv) > 1:
-            name = argv[1]
-
+            project = argv[1]
+        if len(argv) > 2:
+            name = argv[2]
         try:
             selected = checks.lookup(project=project, name=name)
         except ValueError as e:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from poucave.app import Check, main, run_check
 
 
 def test_run_check_cli(test_config_toml):
-    sys_argv = ["poucave", "testproject", "hb"]
+    sys_argv = ["poucave", "check", "testproject", "hb"]
     with mock.patch.object(sys, "argv", sys_argv):
         with mock.patch("poucave.app.run_check") as mocked:
             # import side-effect of __main__
@@ -15,14 +15,14 @@ def test_run_check_cli(test_config_toml):
 
 def test_run_check_cli_by_project(test_config_toml):
     with mock.patch("poucave.app.run_check") as mocked:
-        main(["testproject"])
+        main(["check", "testproject"])
     assert mocked.call_count == 2  # See tests/config.toml
 
 
 def test_run_cli_unknown(test_config_toml):
-    result = main(["testproject", "unknown"])
+    result = main(["check", "testproject", "unknown"])
     assert result == 2
-    result = main(["unknown", "hb"])
+    result = main(["check", "unknown", "hb"])
     assert result == 2
 
 


### PR DESCRIPTION
This could technically be a breaking change, but we never exposed nor documented the internal CLI args parsing.
And the interface in Makefile and Docker remain unchanged, so I would argue that we don't bump the major with this PR.

Will support https://bugzilla.mozilla.org/show_bug.cgi?id=1618898