### PR TITLE
Fix safety check for uptake max age

### DIFF
--- a/tests/checks/remotesettings/test_uptake_max_age.py
+++ b/tests/checks/remotesettings/test_uptake_max_age.py
@@ -1,5 +1,3 @@
-import pytest
-
 from checks.remotesettings.uptake_max_age import run
 from tests.utils import patch_async
 

--- a/tests/checks/remotesettings/test_uptake_max_age.py
+++ b/tests/checks/remotesettings/test_uptake_max_age.py
@@ -39,9 +39,9 @@ async def test_positive():
 
 async def test_positive_no_data():
     with patch_async(
-        f"{MODULE}.fetch_redash", return_value=[{**FAKE_ROWS[0], "age_percentiles": []}]
+        f"{MODULE}.fetch_redash", return_value=FAKE_ROWS
     ):
-        status, data = await run(api_key="", max_percentiles={"50": 42})
+        status, data = await run(api_key="", max_percentiles={"50": 42}, channels=["aurora"])
 
     assert status is True
     assert data["percentiles"] == "No broadcast data during this period."
@@ -71,9 +71,3 @@ async def test_filter_by_channel():
         "max_timestamp": "2019-09-16T02:00:00.000",
         "percentiles": {"10": {"value": 100, "max": 99}},
     }
-
-
-async def test_wrong_channel():
-    with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):
-        with pytest.raises(ValueError):
-            await run(api_key="", max_percentiles={"10": 99}, channels=["unknown"])

--- a/tests/checks/remotesettings/test_uptake_max_age.py
+++ b/tests/checks/remotesettings/test_uptake_max_age.py
@@ -38,10 +38,10 @@ async def test_positive():
 
 
 async def test_positive_no_data():
-    with patch_async(
-        f"{MODULE}.fetch_redash", return_value=FAKE_ROWS
-    ):
-        status, data = await run(api_key="", max_percentiles={"50": 42}, channels=["aurora"])
+    with patch_async(f"{MODULE}.fetch_redash", return_value=FAKE_ROWS):
+        status, data = await run(
+            api_key="", max_percentiles={"50": 42}, channels=["aurora"]
+        )
 
     assert status is True
     assert data["percentiles"] == "No broadcast data during this period."


### PR DESCRIPTION
Since I modified the queries to support #364, the aggregation of percentiles has changed.

Before, when not enough data was received over the period the sql query would return:
`{"min_timestamp": "...", "max_timestamp": "...", "age_percentiles": []}`

Now, the filtered channel would just not be present, and the age percentiles never empty.

```
{"min_timestamp": "...", "max_timestamp": "...", "channel": "release", "age_percentiles": [1, 3, 5, 10. ...]},
{"min_timestamp": "...", "max_timestamp": "...", "channel": "beta", "age_percentiles": [1, 3, 5, 10. ...]}
```