### PR TITLE
Remove inconsistent field from remotesettings-recipes check

### DIFF
--- a/checks/normandy/remotesettings_recipes.py
+++ b/checks/normandy/remotesettings_recipes.py
@@ -2,8 +2,8 @@
 The recipes in the Remote Settings collection should match the Normandy API. The
 collection of recipes with capabilities should contain all baseline recipes.
 
-The lists of missing and extraneous recipes are returned, as well the list of
-inconsistencies between the baseline and capabilities collections.
+The lists of missing and extraneous recipes are returned for the baseline and
+capabilities collections.
 """
 from poucave.typings import CheckResult
 from poucave.utils import fetch_json
@@ -55,22 +55,15 @@ async def run(normandy_server: str, remotesettings_server: str) -> CheckResult:
     missing_caps, extras_caps = compare_recipes_lists(
         normandy_recipes_caps, rs_recipes_caps
     )
-    # Make sure the baseline recipes are all listed in the capabilities collection.
-    inconsistent, _ = compare_recipes_lists(rs_recipes_baseline, rs_recipes_caps)
 
     ok = (
         len(missing_baseline)
         + len(missing_caps)
         + len(extras_baseline)
         + len(extras_caps)
-        + len(inconsistent)
     ) == 0
     data = {
         "baseline": {"missing": missing_baseline, "extras": extras_baseline},
-        "capabilities": {
-            "missing": missing_caps,
-            "extras": extras_caps,
-            "inconsistent": inconsistent,
-        },
+        "capabilities": {"missing": missing_caps, "extras": extras_caps},
     }
     return ok, data


### PR DESCRIPTION
This field is redundant with other fields, and makes the result a bit confusing.

It was defined like this: `caps.inconsistent = rs.base - rs.caps`

But when the capabilities collection is in-sync with Normandy, then this inconsistent list always equals to the list of baseline extras.

Let's try to prove it :)

```
rs.caps = n.caps
rs.base = n.base + base.extras
```

Hence:
```
caps.inconsistent = rs.base - rs.caps
caps.inconsistent = rs.base - n.caps
caps.inconsistent = base.extras + n.caps - n.caps
caps.inconsistent = base.extras
```

And also in the case the capabilities collection is not in-sync with Normandy, and if we consider that all baseline recipes are also listed in capabilities on the Normandy server, then the inconsistent list equals to the list of missing capabilities.

```
n.base - n.caps = 0
rs.base = n.base + base.extras
```

```
caps.missing = n.caps - rs.caps
rs.caps = n.caps - caps.missing
```

Hence:
```
caps.inconsistent = rs.base - rs.caps
caps.inconsistent = rs.base - n.caps + caps.missing
caps.inconsistent = n.base + base.extras - n.caps + caps.missing
caps.inconsistent = base.extras + caps.missing
```

![](https://media.giphy.com/media/DHqth0hVQoIzS/giphy.gif)