### PR TITLE
Add ability to ignore source in uptake error check

### DIFF
--- a/checks/remotesettings/uptake_error_rate.py
+++ b/checks/remotesettings/uptake_error_rate.py
@@ -27,6 +27,18 @@ def sort_dict_desc(d, key):
     return dict(sorted(d.items(), key=key, reverse=True))
 
 
+def parse_ignore_status(ign):
+    source, status, version = "*", ign, "*"
+    if "@" in ign:
+        status, version = ign.split("@")
+    if "/" in status or "-" in status:
+        source = status
+        status = "*"
+    if ":" in source:
+        source, status = source.split(":")
+    return (source, status, version)
+
+
 async def run(
     api_key: str,
     max_error_percentage: float,
@@ -46,12 +58,7 @@ async def run(
     # specific version (eg. ``parse_error@68``)
     ignored_statuses = []
     for ign in ignore_status:
-        source, status, version = "*", ign, "*"
-        if "@" in ign:
-            status, version = ign.split("@")
-        if ":" in status:
-            source, status = status.split(":")
-        ignored_statuses.append((source, status, version))
+        ignored_statuses.append(parse_ignore_status(ign))
     ignored_statuses.extend([("*", "*", str(version)) for version in ignore_versions])
 
     # We will store reported events by period, by source,

--- a/tests/checks/remotesettings/test_uptake_error_rate.py
+++ b/tests/checks/remotesettings/test_uptake_error_rate.py
@@ -1,4 +1,6 @@
-from checks.remotesettings.uptake_error_rate import run
+import pytest
+
+from checks.remotesettings.uptake_error_rate import parse_ignore_status, run
 from tests.utils import patch_async
 
 
@@ -313,3 +315,27 @@ async def test_filter_by_channel():
         "min_timestamp": "2020-01-17T08:10:00",
         "max_timestamp": "2020-01-17T08:30:00",
     }
+
+
+@pytest.mark.parametrize(
+    ("ignore", "expected"),
+    [
+        ("network_error", ("*", "network_error", "*")),
+        ("settings-changes-monitoring", ("settings-changes-monitoring", "*", "*")),
+        ("security-state/intermediates", ("security-state/intermediates", "*", "*")),
+        (
+            "security-state/intermediates:parse_error",
+            ("security-state/intermediates", "parse_error", "*"),
+        ),
+        (
+            "security-state/intermediates@68",
+            ("security-state/intermediates", "*", "68"),
+        ),
+        (
+            "security-state/intermediates:parse_error@68",
+            ("security-state/intermediates", "parse_error", "68"),
+        ),
+    ],
+)
+def test_parse_ignore_status(ignore, expected):
+    assert parse_ignore_status(ignore) == expected


### PR DESCRIPTION
Since we already have dedicated checks for the polling part and the global status, I'd like to remove them from the generic error_rate check. 

That means being able to ignore the `settings-changes-monitoring` and `settings-sync` sources.
The previous code would have treated these strings as statuses.