### PR TITLE
Avoid flickering of failing checks

### DIFF
--- a/poucave/html/js/app.js
+++ b/poucave/html/js/app.js
@@ -312,7 +312,7 @@ class Overview extends Component {
             ${focusedCheckContext => (
               slice.map(r => (
                 html`<li>
-                  <a class="text-red" href="#" onClick=${e => {
+                  <a class="${r.isLoading ? "text-gray" : "text-red"}" href="#" onClick=${e => {
                     e.preventDefault();
                     focusedCheckContext.setValue(r.project, r.name);
                   }}>

--- a/poucave/html/js/app.js
+++ b/poucave/html/js/app.js
@@ -230,8 +230,33 @@ class Dashboard extends Component {
 }
 
 class Overview extends Component {
+  constructor() {
+    super();
+    this.failing = new Set();
+  }
+
+  componentDidUpdate() {
+    const { results } = this.props;
+    // Keep track of checks that are failing.
+    Object.values(results)
+      .filter(r => !r.isLoading)
+      .forEach(({ project, name, success }) => {
+        if (success) {
+          this.failing.delete(`${project}.${name}`);
+        } else {
+          this.failing.add(`${project}.${name}`);
+        }
+      });
+  }
+
   render({ checks, results }) {
-    const failing = Object.values(results).filter(r => !r.isLoading && !r.success);
+    // Show the loading checks that were previously failing.
+    const failing = Object.values(results)
+      .filter(r => (
+        (r.isLoading && this.failing.has(`${r.project}.${r.name}`)) ||
+        (!r.isLoading && !r.success)
+      ));
+
     const isHealthy = failing.length == 0;
 
     const iconClass = isHealthy ? "fa-check-circle text-green" : "fa-times-circle text-red";

--- a/poucave/html/js/app.js
+++ b/poucave/html/js/app.js
@@ -312,7 +312,7 @@ class Overview extends Component {
             ${focusedCheckContext => (
               slice.map(r => (
                 html`<li>
-                  <a class="${r.isLoading ? "text-gray" : "text-red"}" href="#" onClick=${e => {
+                  <a class="${r.isLoading ? "text-gray-medium" : "text-red"}" href="#" onClick=${e => {
                     e.preventDefault();
                     focusedCheckContext.setValue(r.project, r.name);
                   }}>

--- a/poucave/html/js/app.js
+++ b/poucave/html/js/app.js
@@ -1,5 +1,8 @@
 import { html, createContext, Component, render } from './htm_preact.module.js';
 
+const DOMAIN = window.location.href.split('/')[2];
+const ROOT_URL = `${window.location.protocol}//${DOMAIN}`
+
 const FocusedCheck = createContext({
   project: null,
   name: null,
@@ -50,7 +53,8 @@ class Dashboard extends Component {
   }
 
   async componentDidMount() {
-    const response = await fetch("/checks");
+    const url = new URL("/checks", ROOT_URL);
+    const response = await fetch(url.toString());
     const checksData = await response.json();
 
     // Sort by project/name.
@@ -136,8 +140,7 @@ class Dashboard extends Component {
       results,
     }, async () => {
       const {refreshSecret = null} = options;
-      const domain = window.location.href.split('/')[2];
-      const url = new URL(check.url, `${window.location.protocol}//${domain}`);
+      const url = new URL(check.url, ROOT_URL);
       if (refreshSecret) {
         url.searchParams.append("refresh", refreshSecret);
       }


### PR DESCRIPTION
In order to keep of failing checks stable while reloading them, I made this trick. I wonder if there would be a better pattern, using the lifecycle methods for example.