### PR TITLE
Reformat latest approvals as list sorted by datetime

### DIFF
--- a/checks/remotesettings/latest_approvals.py
+++ b/checks/remotesettings/latest_approvals.py
@@ -127,13 +127,14 @@ async def run(
     ]
     results = await run_parallel(*futures)
 
-    # Sort collections by latest approval descending.
-    date_sorted = sorted(
-        zip(source_collections, results),
-        key=lambda item: item[1][0]["datetime"] if len(item[1]) > 0 else "0000-00-00",
-        reverse=True,
-    )
+    collections_entries = []
+    for (bid, cid), entries in zip(source_collections, results):
+        for entry in entries:
+            collections_entries.append({"source": f"{bid}/{cid}", **entry})
 
-    approvals = {f"{bid}/{cid}": entries for (bid, cid), entries in date_sorted}
+    # Sort collections by latest approval descending.
+    approvals = sorted(
+        collections_entries, key=lambda item: item["datetime"], reverse=True,
+    )
 
     return True, approvals

--- a/tests/checks/remotesettings/test_latest_approvals.py
+++ b/tests/checks/remotesettings/test_latest_approvals.py
@@ -97,4 +97,4 @@ async def test_positive(mock_responses):
             status, data = await run({}, server_url, FAKE_AUTH)
 
     assert status is True
-    assert data == {"bid/cid": INFOS}
+    assert data == [{"source": "bid/cid", **INFOS[0]}]


### PR DESCRIPTION
Before we were returning the latest approvals by collection, with a list of latest approvals for each.

Now we return the list of approvals sorted by descending datetime, without grouping by collection.