### PR TITLE
Add check for CRLite filter age.

### DIFF
--- a/checks/remotesettings/crlite_filter_age.py
+++ b/checks/remotesettings/crlite_filter_age.py
@@ -1,0 +1,26 @@
+"""
+The CRLite filter is automatically regenerated multiple times a day, so the
+published filter should always be recent. This check makes sure the filter
+isn't too old, and returns the current age of the filter in hours.
+"""
+from time import time
+
+from poucave.typings import CheckResult
+
+from .utils import KintoClient
+
+
+EXPOSED_PARAMETERS = ["server", "bucket", "collection", "max_filter_age_hours"]
+
+
+async def run(
+    server: str,
+    bucket: str = "security-state",
+    collection: str = "cert-revocations",
+    max_filter_age_hours: int = 24,
+) -> CheckResult:
+    client = KintoClient(server_url=server)
+    records = await client.get_records(bucket=bucket, collection=collection)
+    filter_timestamp = max(r.get("effectiveTimestamp", 0) for r in records)
+    filter_age_hours = (time() - filter_timestamp // 1000) // 3600
+    return filter_age_hours <= max_filter_age_hours, filter_age_hours

--- a/tests/checks/remotesettings/test_crlite_filter_age.py
+++ b/tests/checks/remotesettings/test_crlite_filter_age.py
@@ -1,0 +1,34 @@
+from time import time
+
+from checks.remotesettings.crlite_filter_age import run
+
+
+SERVER_URL = "http://fake.local/v1"
+RECORDS_URL = (
+    SERVER_URL + "/buckets/security-state/collections/cert-revocations/records"
+)
+
+
+def add_mock_responses(mock_responses, hours):
+    now = time() * 1000
+    records = [
+        {"id": str(i), "effectiveTimestamp": now - h * 3600 * 1000}
+        for i, h in enumerate(hours)
+    ]
+    mock_responses.get(RECORDS_URL, payload={"data": records})
+
+
+async def test_positive(mock_responses):
+    add_mock_responses(mock_responses, [11, 5, 42])
+
+    status, data = await run(SERVER_URL)
+    assert status is True
+    assert data == 5
+
+
+async def test_negative(mock_responses):
+    add_mock_responses(mock_responses, [61, 55, 42])
+
+    status, data = await run(SERVER_URL)
+    assert status is False
+    assert data == 42


### PR DESCRIPTION
This adds a check to verify the current age of the CRLite filter.

I feel impure for not mocking `time.time()` in the unit tests, but I can't be bothered, and it should be fine in this case.