### PR TITLE
Catch TypeError when plot data is None

### DIFF
--- a/poucave/app.py
+++ b/poucave/app.py
@@ -380,7 +380,7 @@ def _log_result(event, payload):
     if check.plot is not None:
         try:
             infos["plot"] = float(utils.extract_json(check.plot, result["data"]))
-        except ValueError as e:
+        except (ValueError, TypeError) as e:
             # Ignore errors on checks which return error string in data on failure.
             logger.warning(e)
 

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -350,7 +350,10 @@ async def test_logging_result(caplog, cli, mock_aioresponses):
     mock_aioresponses.get(
         "http://server.local/__heartbeat__", status=503, payload="Boom"
     )
+    # Return null value.
+    mock_aioresponses.get("http://server.local/__heartbeat__", payload={"field": None})
 
+    await cli.get("/checks/project/plot")
     await cli.get("/checks/project/plot")
     await cli.get("/checks/project/plot")
     await cli.get("/checks/project/plot")
@@ -369,6 +372,9 @@ async def test_logging_result(caplog, cli, mock_aioresponses):
     assert not result_logs[2].success
     assert result_logs[2].plot is None
     assert result_logs[2].data == '"Boom"'
+
+    assert result_logs[3].plot is None
+    assert result_logs[3].data == '{"field": null}'
 
 
 async def test_cors_enabled(cli):


### PR DESCRIPTION
`float(None)` raises `TypeError` and not `ValueError`

See https://sentry.prod.mozaws.net/operations/poucave-prod/issues/9772603/?environment=prod