### PR TITLE
Return CRLite filter age as floating-point number.

### DIFF
--- a/checks/remotesettings/crlite_filter_age.py
+++ b/checks/remotesettings/crlite_filter_age.py
@@ -23,5 +23,5 @@ async def run(
     client = KintoClient(server_url=server)
     records = await client.get_records(bucket=bucket, collection=collection)
     filter_timestamp = max(r.get("effectiveTimestamp", 0) for r in records)
-    filter_age_hours = (time() - filter_timestamp // 1000) // 3600
+    filter_age_hours = (time() - filter_timestamp // 1000) / 3600
     return filter_age_hours <= max_filter_age_hours, filter_age_hours

--- a/tests/checks/remotesettings/test_crlite_filter_age.py
+++ b/tests/checks/remotesettings/test_crlite_filter_age.py
@@ -23,7 +23,7 @@ async def test_positive(mock_responses):
 
     status, data = await run(SERVER_URL)
     assert status is True
-    assert data == 5
+    assert 5 <= data <= 5.01
 
 
 async def test_negative(mock_responses):
@@ -31,4 +31,4 @@ async def test_negative(mock_responses):
 
     status, data = await run(SERVER_URL)
     assert status is False
-    assert data == 42
+    assert 42 <= data <= 42.01


### PR DESCRIPTION
Now that we can plot the filter age, it would be nicer not to round it to full hours.