### PR TITLE
Ref #497: Bust cache when comparing push timestamps

### DIFF
--- a/checks/remotesettings/attachments_availability.py
+++ b/checks/remotesettings/attachments_availability.py
@@ -20,13 +20,13 @@ async def test_url(url):
 
 
 async def run(server: str) -> CheckResult:
-    client = KintoClient(server_url=server, bucket="monitor", collection="changes")
+    client = KintoClient(server_url=server)
 
     info = await client.server_info()
     base_url = info["capabilities"]["attachments"]["base_url"]
 
     # Fetch collections records in parallel.
-    entries = await client.get_records()
+    entries = await client.get_monitor_changes()
     futures = [
         client.get_records(
             bucket=entry["bucket"],

--- a/checks/remotesettings/certificates_expiration.py
+++ b/checks/remotesettings/certificates_expiration.py
@@ -40,8 +40,8 @@ async def fetch_collection_metadata(server_url, entry):
 
 
 async def run(server: str, min_remaining_days: int) -> CheckResult:
-    client = KintoClient(server_url=server, bucket="monitor", collection="changes")
-    entries = await client.get_records()
+    client = KintoClient(server_url=server)
+    entries = await client.get_monitor_changes()
 
     # First, fetch all collections metadata in parallel.
     futures = [fetch_collection_metadata(server, entry) for entry in entries]

--- a/checks/remotesettings/changes_timestamps.py
+++ b/checks/remotesettings/changes_timestamps.py
@@ -4,8 +4,6 @@ Timestamps of entries in monitoring endpoint should match collection timestamp.
 For each collection the change `entry` timestamp is returned along with the
 `collection` timestamp. The `datetime` is the human-readable version.
 """
-import random
-
 from poucave.typings import CheckResult
 from poucave.utils import run_parallel, utcfromtimestamp
 
@@ -16,10 +14,9 @@ EXPOSED_PARAMETERS = ["server"]
 
 
 async def run(server: str) -> CheckResult:
-    client = KintoClient(server_url=server, bucket="monitor", collection="changes")
+    client = KintoClient(server_url=server)
     # Make sure we obtain the latest list of changes (bypass webhead microcache)
-    random_cache_bust = random.randint(999999000000, 999999999999)
-    entries = await client.get_records(_expected=random_cache_bust)
+    entries = await client.get_monitor_changes(bust_cache=True)
     futures = [
         client.get_records_timestamp(
             bucket=entry["bucket"],

--- a/checks/remotesettings/cloudfront_invalidations.py
+++ b/checks/remotesettings/cloudfront_invalidations.py
@@ -25,7 +25,7 @@ async def fetch_timestamps(client, bucket, collection):
 
 async def run(server: str, cdn: str, min_age: int = 300) -> CheckResult:
     origin_client = KintoClient(server_url=server)
-    entries = await origin_client.get_records(bucket="monitor", collection="changes")
+    entries = await origin_client.get_monitor_changes()
 
     # Fetch timestamps on source server.
     origin_futures = [

--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -6,6 +6,7 @@ Both values are returned.
 """
 import json
 import logging
+import random
 
 import websockets
 
@@ -41,7 +42,10 @@ async def get_push_timestamp(uri) -> str:
 
 async def get_remotesettings_timestamp(uri) -> str:
     client = KintoClient(server_url=uri)
-    entries = await client.get_records(bucket="monitor", collection="changes")
+    random_cache_bust = random.randint(999999000000, 999999999999)
+    entries = await client.get_records(
+        bucket="monitor", collection="changes", _expected=random_cache_bust
+    )
     # Some collections are excluded (eg. preview)
     # https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/kinto/puppet/modules/kinto/templates/kinto.ini.erb
     matched = [e for e in entries if "preview" not in e["bucket"]]

--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -6,7 +6,6 @@ Both values are returned.
 """
 import json
 import logging
-import random
 
 import websockets
 
@@ -42,10 +41,7 @@ async def get_push_timestamp(uri) -> str:
 
 async def get_remotesettings_timestamp(uri) -> str:
     client = KintoClient(server_url=uri)
-    random_cache_bust = random.randint(999999000000, 999999999999)
-    entries = await client.get_records(
-        bucket="monitor", collection="changes", _expected=random_cache_bust
-    )
+    entries = await client.get_monitor_changes(bust_cache=True)
     # Some collections are excluded (eg. preview)
     # https://github.com/mozilla-services/cloudops-deployment/blob/master/projects/kinto/puppet/modules/kinto/templates/kinto.ini.erb
     matched = [e for e in entries if "preview" not in e["bucket"]]

--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -73,8 +73,10 @@ class KintoClient:
     @retry_timeout
     async def get_monitor_changes(self, bust_cache=False, **kwargs) -> List[Dict]:
         if bust_cache:
+            if "_expected" in kwargs:
+                raise ValueError("Pick one of `bust_cache` and `_expected` parameters")
             random_cache_bust = random.randint(999999000000, 999999999999)
-            kwargs.setdefault("_expected", random_cache_bust)
+            kwargs["_expected"] = random_cache_bust
         return await self.get_records(bucket="monitor", collection="changes", **kwargs)
 
     @retry_timeout

--- a/checks/remotesettings/utils.py
+++ b/checks/remotesettings/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import copy
+import random
 from typing import Dict, List, Optional, Tuple
 
 import backoff
@@ -68,6 +69,13 @@ class KintoClient:
         return await loop.run_in_executor(
             None, lambda: self._client.get_records(*args, **kwargs)
         )
+
+    @retry_timeout
+    async def get_monitor_changes(self, bust_cache=False, **kwargs) -> List[Dict]:
+        if bust_cache:
+            random_cache_bust = random.randint(999999000000, 999999999999)
+            kwargs.setdefault("_expected", random_cache_bust)
+        return await self.get_records(bucket="monitor", collection="changes", **kwargs)
 
     @retry_timeout
     async def get_record(self, *args, **kwargs) -> Dict:

--- a/checks/remotesettings/validate_signatures.py
+++ b/checks/remotesettings/validate_signatures.py
@@ -52,9 +52,11 @@ async def validate_signature(verifier, metadata, records, timestamp):
 
 
 async def run(server: str, buckets: List[str], root_hash: str) -> CheckResult:
-    client = KintoClient(server_url=server, bucket="monitor", collection="changes")
+    client = KintoClient(server_url=server)
     entries = [
-        entry for entry in await client.get_records() if entry["bucket"] in buckets
+        entry
+        for entry in await client.get_monitor_changes()
+        if entry["bucket"] in buckets
     ]
 
     # Fetch collections records in parallel.

--- a/tests/checks/remotesettings/test_utils.py
+++ b/tests/checks/remotesettings/test_utils.py
@@ -139,3 +139,23 @@ async def test_user_agent(mock_responses):
     user_agent = mock_responses.calls[0].request.headers["User-Agent"]
     assert "poucave" in user_agent
     assert "kinto_http" in user_agent
+
+
+async def test_get_monitor_changes(mock_responses):
+    server_url = "http://fake.local/v1"
+    monitor_url = f"{server_url}/buckets/monitor/collections/changes/records"
+    mock_responses.get(monitor_url, payload={})
+
+    client = KintoClient(server_url=server_url)
+
+    await client.get_monitor_changes()
+    assert mock_responses.calls[0].request.params == {}
+
+    await client.get_monitor_changes(bust_cache=True)
+    assert "_expected" in mock_responses.calls[1].request.params
+
+    await client.get_monitor_changes(_expected="bim")
+    assert mock_responses.calls[2].request.params["_expected"] == "bim"
+
+    with pytest.raises(ValueError):
+        await client.get_monitor_changes(bust_cache=True, _expected="boom")


### PR DESCRIPTION
On `main` branch:

```
{
  "push": {
    "timestamp": "1605261258707",
    "datetime": "2020-11-13T09:54:18.707000+00:00"
  },
  "remotesettings": {
    "timestamp": "1605259971562",
    "datetime": "2020-11-13T09:32:51.562000+00:00"
  }
}
```

With this PR:

```
{
  "push": {
    "timestamp": "1605261258707",
    "datetime": "2020-11-13T09:54:18.707000+00:00"
  },
  "remotesettings": {
    "timestamp": "1605261258707",
    "datetime": "2020-11-13T09:54:18.707000+00:00"
  }
}
 
```