### PR TITLE
Adjust push timestamp comparison to support 5min lag

### DIFF
--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -10,7 +10,7 @@ import logging
 import websockets
 
 from poucave.typings import CheckResult
-from poucave.utils import utcfromtimestamp
+from poucave.utils import utcfromtimestamp, utcnow
 
 from .utils import KintoClient
 
@@ -58,7 +58,8 @@ async def run(
     push_datetime = utcfromtimestamp(push_timestamp)
 
     return (
-        0 <= (rs_datetime - push_datetime).seconds < lag_margin,
+        # Fail if timestamps are different and data was published a while ago.
+        rs_timestamp == push_timestamp or (utcnow() - rs_datetime).seconds < lag_margin,
         {
             "push": {
                 "timestamp": push_timestamp,

--- a/checks/remotesettings/push_timestamp.py
+++ b/checks/remotesettings/push_timestamp.py
@@ -48,7 +48,9 @@ async def get_remotesettings_timestamp(uri) -> str:
     return str(matched[0]["last_modified"])
 
 
-async def run(remotesettings_server: str, push_server: str) -> CheckResult:
+async def run(
+    remotesettings_server: str, push_server: str, lag_margin: int = 600
+) -> CheckResult:
     rs_timestamp = await get_remotesettings_timestamp(remotesettings_server)
     push_timestamp = await get_push_timestamp(push_server)
 
@@ -56,7 +58,7 @@ async def run(remotesettings_server: str, push_server: str) -> CheckResult:
     push_datetime = utcfromtimestamp(push_timestamp)
 
     return (
-        push_timestamp == rs_timestamp,
+        0 <= (rs_datetime - push_datetime).seconds < lag_margin,
         {
             "push": {
                 "timestamp": push_timestamp,


### PR DESCRIPTION
Since the push timestamp is now published from lambda, we need to allow
some lag between the source and the destination