### PR TITLE
Fix #383: reflect focused in URL and vice-versa 

### DIFF
--- a/poucave/html/css/main.css
+++ b/poucave/html/css/main.css
@@ -112,22 +112,6 @@ section.project:not(:first-child) {
     max-width: 100%;
 }
 
-@keyframes blinking {
-    0%, 50%, 100% {
-        transform: scale(1, 1);
-        opacity: 1;
-    }
-
-    25%, 75% {
-        transform: scale(0.9, 0.9);
-        opacity: 0.35;
-    }
-}
-
-.animate-blink {
-    animation: blinking 1s 1;
-}
-
 .check-buglist li {
     padding-left: 2em;
     min-height: 1.5em;

--- a/poucave/html/js/app/components/Check.mjs
+++ b/poucave/html/js/app/components/Check.mjs
@@ -18,6 +18,13 @@ export default class Check extends Component {
 
   componentDidMount() {
     document.body.addEventListener("keydown", this.onKeyDown);
+
+    // Focused check on page load?
+    const { data } = this.props;
+    const { project, name } = this.props.focusedCheckContext;
+    if (project === data.project && name === data.name) {
+      this.setState({ detailsOpened: true });
+    }
   }
 
   componentWillUnmount() {

--- a/poucave/html/js/app/components/Check.mjs
+++ b/poucave/html/js/app/components/Check.mjs
@@ -117,7 +117,17 @@ export default class Check extends Component {
 
   handleToggleDetails(ev) {
     ev.preventDefault();
+    const { setValue } = this.props.focusedCheckContext;
     const { detailsOpened } = this.state;
-    this.setState({ detailsOpened: !detailsOpened });
+    if (detailsOpened) {
+      // Remove focused check context on close.
+      setValue(null, null);
+    } else {
+      // Mark check as focused on open.
+      const { data: { project, name } } = this.props;
+      setValue(project, name);
+    }
+    // Context change will toggle `state.detailsOpened`.
+    // See `componentDidUpdate()`.
   }
 }

--- a/poucave/html/js/app/components/Check.mjs
+++ b/poucave/html/js/app/components/Check.mjs
@@ -6,12 +6,11 @@ import Markdown from "./Markdown.mjs";
 export default class Check extends Component {
   constructor() {
     super();
-    this.cardRef = {};
+
     this.state = {
-      focused: false,
       detailsOpened: false,
     };
-    this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
+
     this.handleRefreshButtonClick = this.handleRefreshButtonClick.bind(this);
     this.handleToggleDetails = this.handleToggleDetails.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
@@ -39,27 +38,10 @@ export default class Check extends Component {
     const focusChanged = prevProject !== project || prevName !== name;
 
     if (focusChanged) {
-      if (project === data.project && name === data.name) {
-        this.setState({
-          focused: true,
-        });
-        const card = this.cardRef.current;
-        card.scrollIntoView({
-          behavior: "smooth",
-          block: "center",
-        });
-      } else {
-        this.setState({
-          focused: false,
-        });
-      }
+      this.setState({
+        detailsOpened: project === data.project && name === data.name,
+      });
     }
-  }
-
-  handleAnimationEnd() {
-    const { setValue } = this.props.focusedCheckContext;
-    this.setState({ detailsOpened: true });
-    setValue(null, null);
   }
 
   handleRefreshButtonClick() {
@@ -115,13 +97,10 @@ export default class Check extends Component {
   }
 
   render({ data, result, fetchCheckResult }) {
-    const cardClass = this.state.focused ? "animate-blink" : "";
     return html`
       <div
-        ref="${this.cardRef}"
-        class="check-card card ${cardClass}"
+        class="check-card card"
         id="check--${data.project}--${data.name}"
-        onAnimationEnd="${this.handleAnimationEnd}"
       >
         ${this.renderHeader()}
         ${this.renderBody()}


### PR DESCRIPTION
I wanted to do something simple here.

Unfortunately I could not find an elegant way to distinguish animation on context change and details opening/closing without duplicating a lot of code.

By getting rid of the animation, everything remains relatively straightforward. And in terms of UX it makes sense I think, links on the diagram open the details panel without scrolling for example. And a user «browsing» the cards doesn't need scroll. For permalinks, it is more debatable, but not scrolling is not insane.

I was hesitating with using the history state API, but thought that parsing the URL hash was simple enough. Calling  context `setValue()` down the line instead of using simple links in the diagram and checks is debatable. The codebase would be simpler, the only inconvenient is that the URL hash formatting would break DRY, but it's extremely dumb.  What do you think?
