### PR TITLE
Remove check about XML timestamp

### DIFF
--- a/checks/remotesettings/blocked_pages.py
+++ b/checks/remotesettings/blocked_pages.py
@@ -76,8 +76,6 @@ async def run(remotesettings_server: str, blocked_pages: str) -> CheckResult:
         len(missing) == 0
         and len(missing_ids) == 0
         and len(extras_ids) == 0
-        and xml_timestamp
-        in (addons_timestamp, plugins_timestamp, certificates_timestamp)
     )
     data = {
         "xml-update": xml_timestamp,

--- a/checks/remotesettings/blocked_pages.py
+++ b/checks/remotesettings/blocked_pages.py
@@ -72,11 +72,7 @@ async def run(remotesettings_server: str, blocked_pages: str) -> CheckResult:
     root = xml.etree.ElementTree.fromstring(xml_content)
     xml_timestamp = int(root.attrib["lastupdate"])
 
-    success = (
-        len(missing) == 0
-        and len(missing_ids) == 0
-        and len(extras_ids) == 0
-    )
+    success = len(missing) == 0 and len(missing_ids) == 0 and len(extras_ids) == 0
     data = {
         "xml-update": xml_timestamp,
         "addons-timestamp": addons_timestamp,


### PR DESCRIPTION
For a reason that I don't explain, the XML update timestamp is roughly a
day behind the source collection timestamps.

https://bugzilla.mozilla.org/show_bug.cgi?id=1675807

This XML is used by Firefox < 68, and although it's still live, we don't support it anymore and don't want to spend human resources for this.

Let's remove this failing check that prevents us from concentrating on
real stuff.