### PR TITLE
Optimize Uptake queries using check parameters

### DIFF
--- a/checks/remotesettings/uptake_max_duration.py
+++ b/checks/remotesettings/uptake_max_duration.py
@@ -49,7 +49,7 @@ SELECT
     APPROX_QUANTILES(duration, 100) AS duration_percentiles
 FROM filtered_telemetry
 WHERE duration > 0
-  AND source = {source}
+  AND source = '{source}'
 GROUP BY channel, source
 -- We sort channel DESC to have release first for retrocompat reasons.
 ORDER BY channel DESC, source, min_timestamp

--- a/poucave/utils.py
+++ b/poucave/utils.py
@@ -249,6 +249,14 @@ def cast_value(_type, value):
                 raise
 
 
+def csv_quoted(values):
+    """
+    >>> csv_quoted([1, 2, 3])
+    "'1','2','3'"
+    """
+    return ",".join(f"'{v}'" for v in values)
+
+
 def extract_json(path, data):
     """
     A very simple and dumb implementation of JSONPath

--- a/tests/checks/normandy/test_normandy_jexl_error_rate.py
+++ b/tests/checks/normandy/test_normandy_jexl_error_rate.py
@@ -47,27 +47,11 @@ FAKE_ROWS = [
         "min_timestamp": datetime.fromisoformat("2019-09-16T01:36:12.348"),
         "max_timestamp": datetime.fromisoformat("2019-09-16T07:24:58.741"),
     },
-    {
-        "status": "success",
-        "source": "normandy/recipe/531",
-        "channel": "beta",
-        "total": 100,
-        "min_timestamp": datetime.fromisoformat("2019-09-16T01:36:12.348"),
-        "max_timestamp": datetime.fromisoformat("2019-09-16T07:24:58.741"),
-    },
-    {
-        "status": "content_error",
-        "source": "normandy/recipe/531",
-        "channel": "beta",
-        "total": 100,
-        "min_timestamp": datetime.fromisoformat("2019-09-16T01:36:12.348"),
-        "max_timestamp": datetime.fromisoformat("2019-09-16T07:24:58.741"),
-    },
 ]
 
 
 async def test_positive():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+    with patch_async(f"{MODULE}.fetch_normandy_uptake", return_value=FAKE_ROWS):
         status, data = await run(max_error_percentage=100.0, channels=["release"])
 
     assert status is True
@@ -78,20 +62,8 @@ async def test_positive():
     }
 
 
-async def test_filter_by_channel():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        status, data = await run(max_error_percentage=100.0, channels=["beta"])
-
-    assert status is True
-    assert data == {
-        "error_rate": 50.0,
-        "min_timestamp": "2019-09-16T01:36:12.348000",
-        "max_timestamp": "2019-09-16T07:24:58.741000",
-    }
-
-
 async def test_negative():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+    with patch_async(f"{MODULE}.fetch_normandy_uptake", return_value=FAKE_ROWS):
         status, data = await run(max_error_percentage=1.0, channels=["release"])
 
     assert status is False

--- a/tests/checks/normandy/test_normandy_uptake_error_rate.py
+++ b/tests/checks/normandy/test_normandy_uptake_error_rate.py
@@ -112,22 +112,6 @@ FAKE_ROWS = [
         "channel": "release",
         "total": 1000,
     },
-    {
-        "min_timestamp": datetime.fromisoformat("2019-09-16T00:50:00"),
-        "max_timestamp": datetime.fromisoformat("2019-09-16T01:00:00"),
-        "status": "recipe_filter_broken",
-        "source": "normandy/recipe/531",
-        "channel": "beta",
-        "total": 1000,
-    },
-    {
-        "min_timestamp": datetime.fromisoformat("2019-09-16T00:50:00"),
-        "max_timestamp": datetime.fromisoformat("2019-09-16T01:00:00"),
-        "status": "recipe_didnt_match_filter",
-        "source": "normandy/recipe/531",
-        "channel": "beta",
-        "total": 3000,
-    },
 ]
 
 RECIPE = {
@@ -322,42 +306,6 @@ async def test_filter_on_runner_uptake(mock_aioresponses):
         },
         "min_rate": 0.0,
         "max_rate": 20.0,
-        "min_timestamp": "2019-09-16T00:30:00",
-        "max_timestamp": "2019-09-16T01:00:00",
-    }
-
-
-async def test_filter_by_channel(mock_aioresponses):
-    mock_aioresponses.get(
-        NORMANDY_URL.format(server=NORMANDY_SERVER),
-        payload=[{"recipe": {**RECIPE, "id": 531}}],
-    )
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        status, data = await run(
-            server=NORMANDY_SERVER,
-            max_error_percentage=0.1,
-            channels=["beta"],
-        )
-
-    assert status is False
-    assert data == {
-        "sources": {
-            "recipe/531": {
-                "error_rate": 25.0,
-                "name": "un dos tres",
-                "with_telemetry": False,
-                "with_classify_client": False,
-                "ignored": {},
-                "max_timestamp": "2019-09-16T01:00:00",
-                "min_timestamp": "2019-09-16T00:50:00",
-                "statuses": {
-                    "recipe_didnt_match_filter": 3000,
-                    "recipe_filter_broken": 1000,
-                },
-            }
-        },
-        "min_rate": 25.0,
-        "max_rate": 25.0,
         "min_timestamp": "2019-09-16T00:30:00",
         "max_timestamp": "2019-09-16T01:00:00",
     }

--- a/tests/checks/normandy/test_reported_recipes.py
+++ b/tests/checks/normandy/test_reported_recipes.py
@@ -57,7 +57,7 @@ async def test_positive(mock_aioresponses):
         payload=[{"recipe": {"id": 123}}, {"recipe": {"id": 456}}],
     )
 
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+    with patch_async(f"{MODULE}.fetch_normandy_uptake", return_value=FAKE_ROWS):
         status, data = await run(server=NORMANDY_SERVER)
 
     assert status is True
@@ -78,29 +78,12 @@ async def test_negative(mock_aioresponses):
         ],
     )
 
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+    with patch_async(f"{MODULE}.fetch_normandy_uptake", return_value=FAKE_ROWS):
         status, data = await run(server=NORMANDY_SERVER)
 
     assert status is False
     assert data == {
         "missing": [789],
-        "min_timestamp": "2019-09-16T01:36:12.348000",
-        "max_timestamp": "2019-09-16T07:24:58.741000",
-    }
-
-
-async def test_positive_by_channel(mock_aioresponses):
-    mock_aioresponses.get(
-        NORMANDY_URL.format(server=NORMANDY_SERVER),
-        payload=[{"recipe": {"id": 456}}],
-    )
-
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        status, data = await run(server=NORMANDY_SERVER, channels=["beta"])
-
-    assert status is True
-    assert data == {
-        "missing": [],
         "min_timestamp": "2019-09-16T01:36:12.348000",
         "max_timestamp": "2019-09-16T07:24:58.741000",
     }

--- a/tests/checks/remotesettings/test_uptake_error_rate.py
+++ b/tests/checks/remotesettings/test_uptake_error_rate.py
@@ -55,15 +55,6 @@ FAKE_ROWS = [
         "total": 2500,
     },
     {
-        "min_timestamp": datetime.fromisoformat("2020-01-17T08:10:00"),
-        "max_timestamp": datetime.fromisoformat("2020-01-17T08:20:00"),
-        "status": "unknown_error",
-        "source": "blocklists/addons",
-        "channel": "beta",
-        "version": "75",
-        "total": 4000,
-    },
-    {
         "min_timestamp": datetime.fromisoformat("2020-01-17T08:20:00"),
         "max_timestamp": datetime.fromisoformat("2020-01-17T08:30:00"),
         "status": "success",
@@ -172,7 +163,7 @@ async def test_ignore_status_on_version():
     }
 
 
-async def api():
+async def test_ignore_status_on_source_and_version():
     with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
         status, data = await run(
             max_error_percentage=0.1,
@@ -251,7 +242,7 @@ async def test_min_total_events():
 
 
 async def test_filter_sources():
-    fake_rows = FAKE_ROWS + [
+    fake_rows = [
         {
             "min_timestamp": datetime.fromisoformat("2020-01-17T08:10:00"),
             "max_timestamp": datetime.fromisoformat("2020-01-17T08:20:00"),
@@ -283,11 +274,11 @@ async def test_filter_sources():
         "min_rate": 100.0,
         "max_rate": 100.0,
         "min_timestamp": "2020-01-17T08:10:00",
-        "max_timestamp": "2020-01-17T08:30:00",
+        "max_timestamp": "2020-01-17T08:20:00",
     }
 
 
-async def test_exclude_sources():
+async def test_exclude_status():
     fake_rows = FAKE_ROWS + [
         {
             "min_timestamp": datetime.fromisoformat("2020-01-17T08:10:00"),
@@ -309,29 +300,7 @@ async def test_exclude_sources():
     assert data == {
         "sources": {},
         "min_rate": 0.0,
-        "max_rate": 20.45,
-        "min_timestamp": "2020-01-17T08:10:00",
-        "max_timestamp": "2020-01-17T08:30:00",
-    }
-
-
-async def test_filter_by_channel():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        status, data = await run(max_error_percentage=0, channels=["beta"])
-
-    assert status is False
-    assert data == {
-        "sources": {
-            "blocklists/addons": {
-                "error_rate": 100.0,
-                "ignored": {},
-                "statuses": {"unknown_error": 4000},
-                "min_timestamp": "2020-01-17T08:10:00",
-                "max_timestamp": "2020-01-17T08:20:00",
-            }
-        },
-        "min_rate": 100.0,
-        "max_rate": 100.0,
+        "max_rate": 12.5,
         "min_timestamp": "2020-01-17T08:10:00",
         "max_timestamp": "2020-01-17T08:30:00",
     }

--- a/tests/checks/remotesettings/test_uptake_max_age.py
+++ b/tests/checks/remotesettings/test_uptake_max_age.py
@@ -13,12 +13,6 @@ FAKE_ROWS = [
         "min_timestamp": datetime.fromisoformat("2019-09-16T02:36:12.348"),
         "max_timestamp": datetime.fromisoformat("2019-09-16T06:24:58.741"),
     },
-    {
-        "channel": "beta",
-        "age_percentiles": [i ** 2 for i in range(100)],
-        "min_timestamp": datetime.fromisoformat("2019-09-16T01:00:00.123"),
-        "max_timestamp": datetime.fromisoformat("2019-09-16T02:00:00.123"),
-    },
 ]
 
 
@@ -38,7 +32,7 @@ async def test_positive():
 
 
 async def test_positive_no_data():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+    with patch_async(f"{MODULE}.fetch_bigquery", return_value=[]):
         status, data = await run(max_percentiles={"50": 42}, channels=["aurora"])
 
     assert status is True
@@ -53,17 +47,5 @@ async def test_negative():
     assert data == {
         "min_timestamp": "2019-09-16T02:36:12.348000",
         "max_timestamp": "2019-09-16T06:24:58.741000",
-        "percentiles": {"10": {"value": 100, "max": 99}},
-    }
-
-
-async def test_filter_by_channel():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        status, data = await run(max_percentiles={"10": 99}, channels=["beta"])
-
-    assert status is False
-    assert data == {
-        "min_timestamp": "2019-09-16T01:00:00.123000",
-        "max_timestamp": "2019-09-16T02:00:00.123000",
         "percentiles": {"10": {"value": 100, "max": 99}},
     }

--- a/tests/checks/remotesettings/test_uptake_max_duration.py
+++ b/tests/checks/remotesettings/test_uptake_max_duration.py
@@ -53,13 +53,7 @@ async def test_negative():
     }
 
 
-async def test_bad_source():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
+async def test_bad_source_or_channel():
+    with patch_async(f"{MODULE}.fetch_bigquery", return_value=[]):
         with pytest.raises(ValueError):
             await run(source="unknown", max_percentiles={})
-
-
-async def test_bad_channel():
-    with patch_async(f"{MODULE}.fetch_bigquery", return_value=FAKE_ROWS):
-        with pytest.raises(ValueError):
-            await run(channels=["unknown"], max_percentiles={})


### PR DESCRIPTION
With the previous setup, using Redash, the parameterization of cached queries was limited.

Here we can reduce the amount of scanned data using the checks parameters.