### PR TITLE
Distinguish fetching errors from check errors

### DIFF
--- a/poucave/html/js/app/components/App.mjs
+++ b/poucave/html/js/app/components/App.mjs
@@ -24,6 +24,6 @@ const App = () => {
       </div>
     </div>
   `;
-}
+};
 
 export default App;

--- a/poucave/html/js/app/components/Check.mjs
+++ b/poucave/html/js/app/components/Check.mjs
@@ -39,7 +39,10 @@ export default class Check extends Component {
 
   componentDidUpdate(prevProps) {
     const { project, name } = this.props.focusedCheckContext;
-    const { project: prevProject, name: prevName } = prevProps.focusedCheckContext;
+    const {
+      project: prevProject,
+      name: prevName,
+    } = prevProps.focusedCheckContext;
     const { data } = this.props;
 
     const focusChanged = prevProject !== project || prevName !== name;
@@ -71,7 +74,10 @@ export default class Check extends Component {
 
     return html`
       <div class="card-status card-status-top ${statusClass}"></div>
-      <div class="card-header cursor-pointer" onClick=${this.handleToggleDetails}>
+      <div
+        class="card-header cursor-pointer"
+        onClick=${this.handleToggleDetails}
+      >
         <h4 class="card-title check-name">${data.name}</h4>
         <div class="card-options">
           <span class="ml-3" href="#" title="Show more details">
@@ -90,7 +96,9 @@ export default class Check extends Component {
     if (data.tags.length) {
       tags = html`
         <p class="check-tags lh-1">
-          ${data.tags.map(t => html`<span class="badge mr-1 mb-1">${t}</span>`)}
+          ${data.tags.map(
+            (t) => html`<span class="badge mr-1 mb-1">${t}</span>`
+          )}
         </p>
       `;
     }
@@ -105,12 +113,8 @@ export default class Check extends Component {
 
   render({ data, result, fetchCheckResult }) {
     return html`
-      <div
-        class="check-card card"
-        id="check--${data.project}--${data.name}"
-      >
-        ${this.renderHeader()}
-        ${this.renderBody()}
+      <div class="check-card card" id="check--${data.project}--${data.name}">
+        ${this.renderHeader()} ${this.renderBody()}
         <${CheckDetails}
           data=${data}
           result=${result}
@@ -131,7 +135,9 @@ export default class Check extends Component {
       setValue(null, null);
     } else {
       // Mark check as focused on open.
-      const { data: { project, name } } = this.props;
+      const {
+        data: { project, name },
+      } = this.props;
       setValue(project, name);
     }
     // Context change will toggle `state.detailsOpened`.

--- a/poucave/html/js/app/components/CheckDetails.mjs
+++ b/poucave/html/js/app/components/CheckDetails.mjs
@@ -24,7 +24,9 @@ export default class CheckDetails extends Component {
   }
 
   displayPlot() {
-    const { result: { history = [] } } = this.props;
+    const {
+      result: { history = [] },
+    } = this.props;
     if (history.length === 0) {
       // Data not loaded. Nothing to do.
       return;
@@ -34,25 +36,25 @@ export default class CheckDetails extends Component {
     const failuresPlot = {
       x: [],
       y: [],
-      mode: 'markers',
+      mode: "markers",
       marker: {
         color: PLOT_COLORS.MARKERS_FAILURE,
         size: 12,
-      }
+      },
     };
     // Yellow lines with history of values.
     const scalarPlot = {
       x: [],
       y: [],
-      mode: 'lines',
-      fill: 'tonexty',
+      mode: "lines",
+      fill: "tonexty",
       fillcolor: PLOT_COLORS.FILL_SCALAR,
       line: {
-        shape: 'hvh',
+        shape: "hvh",
         color: PLOT_COLORS.LINE_SCALAR,
         width: 1,
       },
-      type: 'scatter'
+      type: "scatter",
     };
     // This baseline will be used to define the area of fill
     // for the scalar plot (fill=tonexty), instead of
@@ -60,10 +62,10 @@ export default class CheckDetails extends Component {
     const baselinePlot = {
       x: [history[0].t, history[history.length - 1].t],
       y: [],
-      mode: 'lines',
+      mode: "lines",
       line: {
         width: 0,
-      }
+      },
     };
 
     let maxValue = history[0].scalar;
@@ -85,11 +87,7 @@ export default class CheckDetails extends Component {
 
     Plotly.react(
       this.plotDivID,
-      [
-        baselinePlot,
-        scalarPlot,
-        failuresPlot,
-      ],
+      [baselinePlot, scalarPlot, failuresPlot],
       {
         showlegend: false,
         paper_bgcolor: "#00000000", // transparent.
@@ -108,11 +106,11 @@ export default class CheckDetails extends Component {
         yaxis: {
           color: PLOT_COLORS.AXIS,
           gridcolor: PLOT_COLORS.GRID,
-        }
+        },
       },
       {
         staticPlot: true,
-        responsive: true
+        responsive: true,
       }
     );
 
@@ -120,7 +118,7 @@ export default class CheckDetails extends Component {
     if (!this.resizeHandler) {
       this.resizeHandler = () => Plotly.Plots.resize(this.plotDivID);
     }
-    window.addEventListener('resize', this.resizeHandler);
+    window.addEventListener("resize", this.resizeHandler);
     this.resizeHandler();
   }
 
@@ -134,46 +132,52 @@ export default class CheckDetails extends Component {
     fetchCheckResult(data, { refreshSecret });
   }
 
-  render({data, result, opened, onClickCloseButton}) {
+  render({ data, result, opened, onClickCloseButton }) {
     let tags = null;
 
     if (data.tags.length) {
       tags = html`
-      <p class="check-tags lh-1">
-        ${data.tags.map(t => html`<span class="badge mr-1 mb-1">${t}</span>`)}
-      </p>
-    `;
+        <p class="check-tags lh-1">
+          ${data.tags.map(
+            (t) => html`<span class="badge mr-1 mb-1">${t}</span>`
+          )}
+        </p>
+      `;
     }
 
     // Populate the list of params or provide a fallback
     let parameters = html`<em>No parameters.</em>`;
     if (result.parameters && Object.keys(result.parameters).length) {
-      const parameterItems = Object.keys(result.parameters).map(k => (html`
-      <dt>${k}</dt>
-      <dd>${JSON.stringify(result.parameters[k], null, 2)}</dd>
-    `));
+      const parameterItems = Object.keys(result.parameters).map(
+        (k) => html`
+          <dt>${k}</dt>
+          <dd>${JSON.stringify(result.parameters[k], null, 2)}</dd>
+        `
+      );
       parameters = html`<dl>${parameterItems}</dl>`;
     }
 
     let duration = null;
     if (result.duration) {
       duration = html`
-      <span class="float-right text-gray-medium lh-1">
-        Executed in ${result.duration}ms.
-      </span>
-    `;
+        <span class="float-right text-gray-medium lh-1">
+          Executed in ${result.duration}ms.
+        </span>
+      `;
     }
 
     const updated = result.datetime ? new Date(result.datetime) : new Date();
     let resultData = null;
     if (result.data) {
       resultData = html`
-      <h4>Result Data</h4>
-      <pre class="mb-0 check-result">${JSON.stringify(result.data, null, 2)}</pre>
-      <div class="mt-2 mb-3 text-gray-medium">
-        Updated <${TimeAgo} date="${updated}" />
-      </div>
-    `;
+        <h4>Result Data</h4>
+        <pre class="mb-0 check-result">
+${JSON.stringify(result.data, null, 2)}</pre
+        >
+        <div class="mt-2 mb-3 text-gray-medium">
+          Updated <${TimeAgo} date="${updated}" />
+        </div>
+      `;
     }
 
     let plot = html`<em>No history.</em>`;
@@ -184,25 +188,27 @@ export default class CheckDetails extends Component {
     let bugList = html`<em>No bugs.</em>`;
     if (result.buglist && result.buglist.length) {
       bugList = html`
-      <ul>
-        ${result.buglist.map(
-        (bug) => html`<li class="${bug.open ? "open" : "closed"} ${bug.heat}">
-            <a
-              title="${bug.status} - ${bug.summary} (updated: ${bug.last_update})"
-              href="${bug.url}"
-              target="_blank"
+        <ul>
+          ${result.buglist.map(
+            (bug) => html`<li
+              class="${bug.open ? "open" : "closed"} ${bug.heat}"
             >
-              ${bug.id}
-            </a>
-            ${" ("}${bug.status}${", "}${timeago().format(bug.last_update)})
-          </li>`
-      )}
-      </ul>
-    `;
+              <a
+                title="${bug.status} - ${bug.summary} (updated: ${bug.last_update})"
+                href="${bug.url}"
+                target="_blank"
+              >
+                ${bug.id}
+              </a>
+              ${" ("}${bug.status}${", "}${timeago().format(bug.last_update)})
+            </li>`
+          )}
+        </ul>
+      `;
     }
 
     let statusClass = "text-gray";
-    let icon = "question-circle"
+    let icon = "question-circle";
     if (!result.isLoading) {
       statusClass = result.success ? "text-green" : "text-red";
       icon = result.success ? "check-circle" : "times-circle";
@@ -218,7 +224,12 @@ export default class CheckDetails extends Component {
               <span class="ml-2 flex-grow-1">${data.project}/${data.name}</span>
             </h2>
             <span class="ml-3">
-              <a class="check-url text-gray-medium" title="Open check API data" href="${data.url}" target="_blank">
+              <a
+                class="check-url text-gray-medium"
+                title="Open check API data"
+                href="${data.url}"
+                target="_blank"
+              >
                 <i class="fa fa-sm fa-external-link-alt" />
               </a>
             </span>
@@ -228,7 +239,11 @@ export default class CheckDetails extends Component {
                 onClick="${this.handleRefreshButtonClick}"
                 disabled="${result.isLoading}"
               >
-                <i class="fa fa-sync-alt mr-1 ${result.isLoading ? 'fa-spin' : ''}"></i>
+                <i
+                  class="fa fa-sync-alt mr-1 ${result.isLoading
+                    ? "fa-spin"
+                    : ""}"
+                ></i>
                 Refresh
               </button>
             </span>
@@ -257,21 +272,22 @@ export default class CheckDetails extends Component {
           <h4>Parameters</h4>
           <p class="check-parameters">${parameters}</p>
 
-          ${duration}
-          ${resultData}
+          ${duration} ${resultData}
 
           <h4>History</h4>
           <p>${plot}</p>
 
           <h4>Known Issues</h4>
-          <p class="check-buglist lh-1">
-            ${bugList}
-          </p>
+          <p class="check-buglist lh-1">${bugList}</p>
 
           <hr />
 
           <p>
-            <a class="check-troubleshooting" href="${data.troubleshooting}" target="_blank">
+            <a
+              class="check-troubleshooting"
+              href="${data.troubleshooting}"
+              target="_blank"
+            >
               <i class="fa fa-tools"></i> Troubleshooting
             </a>
           </p>

--- a/poucave/html/js/app/components/CheckDetails.mjs
+++ b/poucave/html/js/app/components/CheckDetails.mjs
@@ -166,12 +166,23 @@ export default class CheckDetails extends Component {
       `;
     }
 
+    let statusClass = "text-gray";
+    let icon = "question-circle";
+    if (!result.isLoading) {
+      statusClass = result.success
+        ? "text-green"
+        : result.isIncomplete
+        ? "text-yellow"
+        : "text-red";
+      icon = result.success ? "check-circle" : "times-circle";
+    }
+
     const updated = result.datetime ? new Date(result.datetime) : new Date();
     let resultData = null;
     if (result.data) {
       resultData = html`
         <h4>Result Data</h4>
-        <pre class="mb-0 check-result">
+        <pre class="mb-0 check-result ${statusClass}">
 ${JSON.stringify(result.data, null, 2)}</pre
         >
         <div class="mt-2 mb-3 text-gray-medium">
@@ -205,13 +216,6 @@ ${JSON.stringify(result.data, null, 2)}</pre
           )}
         </ul>
       `;
-    }
-
-    let statusClass = "text-gray";
-    let icon = "question-circle";
-    if (!result.isLoading) {
-      statusClass = result.success ? "text-green" : "text-red";
-      icon = result.success ? "check-circle" : "times-circle";
     }
 
     return html`

--- a/poucave/html/js/app/components/Dashboard.mjs
+++ b/poucave/html/js/app/components/Dashboard.mjs
@@ -155,10 +155,11 @@ export default class Dashboard extends Component {
           result = {
             project: check.project,
             name: check.name,
-            success: false,
             datetime: new Date(),
             data: err.toString(),
             duration: 0,
+            success: false, // Mark as failed.
+            isIncomplete: true, // Distinguish network errors from failing checks.
           };
         } finally {
           const results = {

--- a/poucave/html/js/app/components/Dashboard.mjs
+++ b/poucave/html/js/app/components/Dashboard.mjs
@@ -44,8 +44,8 @@ export default class Dashboard extends Component {
 
     // Execute each check.
     const checks = {};
-    const results = {}
-    checksData.forEach(c => {
+    const results = {};
+    checksData.forEach((c) => {
       const key = `${c.project}.${c.name}`;
       checks[key] = c;
       results[key] = {
@@ -65,7 +65,7 @@ export default class Dashboard extends Component {
 
   componentWillUnmount() {
     const { recheckTimeouts } = this.state;
-    Object.values(recheckTimeouts).forEach(timeoutId => {
+    Object.values(recheckTimeouts).forEach((timeoutId) => {
       clearTimeout(timeoutId);
     });
     window.removeEventListener("hashchange", this.onHashChange);
@@ -86,13 +86,12 @@ export default class Dashboard extends Component {
         },
       });
     }
-
   }
   updateFavicon() {
     const { results } = this.state;
 
-    const isLoading = Object.values(results).some(r => r.isLoading);
-    const isHealthy = Object.values(results).every(r => r.success);
+    const isLoading = Object.values(results).some((r) => r.isLoading);
+    const isHealthy = Object.values(results).every((r) => r.success);
 
     let favicon = "img/loading.png";
     if (!isLoading) {
@@ -107,7 +106,10 @@ export default class Dashboard extends Component {
 
     // Reschedule the check
     const key = `${check.project}.${check.name}`;
-    const timeout = setTimeout(() => this.triggerRecheck(check), check.ttl * 1000);
+    const timeout = setTimeout(
+      () => this.triggerRecheck(check),
+      check.ttl * 1000
+    );
     const recheckTimeouts = {
       ...this.state.recheckTimeouts,
       [key]: timeout,
@@ -125,45 +127,48 @@ export default class Dashboard extends Component {
       [key]: {
         ...this.state.results[key],
         isLoading: true,
-      }
+      },
     };
-    this.setState({
-      results,
-    }, async () => {
-      const {refreshSecret = null} = options;
-      const url = new URL(check.url, ROOT_URL);
-      if (refreshSecret) {
-        url.searchParams.append("refresh", refreshSecret);
-      }
+    this.setState(
+      {
+        results,
+      },
+      async () => {
+        const { refreshSecret = null } = options;
+        const url = new URL(check.url, ROOT_URL);
+        if (refreshSecret) {
+          url.searchParams.append("refresh", refreshSecret);
+        }
 
-      // Fetch the check result and update
-      let response;
-      let result;
-      try {
-        response = await fetch(url.toString());
-        result = await response.json();
-      } catch (err) {
-        if (response && /Invalid refresh secret/.test(response.statusText)) {
-          // Forget about this refresh secret
-          localStorage.removeItem("refresh-secret");
+        // Fetch the check result and update
+        let response;
+        let result;
+        try {
+          response = await fetch(url.toString());
+          result = await response.json();
+        } catch (err) {
+          if (response && /Invalid refresh secret/.test(response.statusText)) {
+            // Forget about this refresh secret
+            localStorage.removeItem("refresh-secret");
+          }
+          console.warn(check.project, check.name, err);
+          result = {
+            project: check.project,
+            name: check.name,
+            success: false,
+            datetime: new Date(),
+            data: err.toString(),
+            duration: 0,
+          };
+        } finally {
+          const results = {
+            ...this.state.results,
+            [key]: result,
+          };
+          this.setState({ results });
         }
-        console.warn(check.project, check.name, err);
-        result = {
-          project: check.project,
-          name: check.name,
-          success: false,
-          datetime: new Date(),
-          data: err.toString(),
-          duration: 0
-        };
-      } finally {
-        const results = {
-          ...this.state.results,
-          [key]: result,
-        }
-        this.setState({results});
       }
-    });
+    );
   }
 
   setFocusedCheck(project, name) {
@@ -187,26 +192,25 @@ export default class Dashboard extends Component {
 
     // Group by project
     const projects = {};
-    Object.values(checks)
-      .forEach(check => {
-        const p = check.project;
-        if (!(p in projects)) {
-          projects[p] = [];
-        }
-        projects[p].push({
-          data: check,
-          result: results[`${check.project}.${check.name}`],
-        });
+    Object.values(checks).forEach((check) => {
+      const p = check.project;
+      if (!(p in projects)) {
+        projects[p] = [];
+      }
+      projects[p].push({
+        data: check,
+        result: results[`${check.project}.${check.name}`],
       });
+    });
 
     return Object.keys(projects).map(
-      name => html`
+      (name) => html`
         <${Project}
           name="${name}"
           checks="${projects[name]}"
           fetchCheckResult="${this.fetchCheckResult}"
         />
-      `,
+      `
     );
   }
 
@@ -222,7 +226,7 @@ export default class Dashboard extends Component {
       <${FocusedCheck.Provider} value="${focusedCheckContext}">
         <${Overview} checks="${checks}" results="${results}" />
         ${this.renderProjects()}
-      </>
+      </${FocusedCheck.Provider}>
     `;
   }
 }

--- a/poucave/html/js/app/components/Markdown.mjs
+++ b/poucave/html/js/app/components/Markdown.mjs
@@ -6,6 +6,6 @@ const Markdown = ({ md }) => {
   };
 
   return html`<div dangerouslySetInnerHTML="${innerHTML}" />`;
-}
+};
 
 export default Markdown;

--- a/poucave/html/js/app/components/Overview.mjs
+++ b/poucave/html/js/app/components/Overview.mjs
@@ -14,7 +14,7 @@ export default class Overview extends Component {
     const { results } = this.props;
     // Keep track of checks that are failing.
     Object.values(results)
-      .filter(r => !r.isLoading)
+      .filter((r) => !r.isLoading)
       .forEach(({ project, name, success }) => {
         if (success) {
           this.failing.delete(`${project}.${name}`);
@@ -26,43 +26,46 @@ export default class Overview extends Component {
 
   render({ checks, results }) {
     // Show the loading checks that were previously failing.
-    const failing = Object.values(results)
-      .filter(r => (
+    const failing = Object.values(results).filter(
+      (r) =>
         (r.isLoading && this.failing.has(`${r.project}.${r.name}`)) ||
         (!r.isLoading && !r.success)
-      ));
+    );
 
     const isHealthy = failing.length == 0;
 
-    const iconClass = isHealthy ? "fa-check-circle text-green" : "fa-times-circle text-red";
+    const iconClass = isHealthy
+      ? "fa-check-circle text-green"
+      : "fa-times-circle text-red";
 
     return html`
       <div class="mt-4 mb-5 overview">
         <${FocusedCheck.Consumer}>
-          ${
-            focusedCheckContext => (html`
-              <${SystemDiagram}
-                checks="${checks}"
-                results="${results}"
-                focusedCheckContext="${focusedCheckContext}"
-              />
-            `)
-          }
-        </>
+          ${(focusedCheckContext) => html`
+            <${SystemDiagram}
+              checks="${checks}"
+              results="${results}"
+              focusedCheckContext="${focusedCheckContext}"
+            />
+          `}
+        </${FocusedCheck.Consumer}>
 
         <div class="card">
           <div class="card-body text-center">
             <i class="fa fa-4x ${iconClass}"></i>
             <p>
-              <strong>The system ${isHealthy ? "is currently healthy" : "has failing checks"}.</strong>
+              <strong
+                >The system
+                ${isHealthy
+                  ? "is currently healthy"
+                  : "has failing checks"}.</strong
+              >
               <br />
               <span class="text-gray-medium">
                 Last updated <${TimeAgo} date="${new Date()}" />.
               </span>
             </p>
-            <div class="error-list">
-              ${this.renderErrorList(failing)}
-            </div>
+            <div class="error-list">${this.renderErrorList(failing)}</div>
           </div>
         </div>
       </div>
@@ -84,19 +87,23 @@ export default class Overview extends Component {
       columns.push(html`
         <ul class="text-red">
           <${FocusedCheck.Consumer}>
-            ${focusedCheckContext => (
-              slice.map(r => (
-                html`<li>
-                  <a class="${r.isLoading ? "text-gray-medium" : "text-red"}" href="#" onClick=${e => {
-                    e.preventDefault();
-                    focusedCheckContext.setValue(r.project, r.name);
-                  }}>
-                    ${r.project} / ${r.name}
-                  </a>
-                </li>`
-              ))
-            )}
-          </>
+            ${(focusedCheckContext) =>
+              slice.map(
+                (r) =>
+                  html`<li>
+                    <a
+                      class="${r.isLoading ? "text-gray-medium" : "text-red"}"
+                      href="#"
+                      onClick=${(e) => {
+                        e.preventDefault();
+                        focusedCheckContext.setValue(r.project, r.name);
+                      }}
+                    >
+                      ${r.project} / ${r.name}
+                    </a>
+                  </li>`
+              )}
+          </${FocusedCheck.Consumer}>
         </ul>
       `);
     }

--- a/poucave/html/js/app/components/Overview.mjs
+++ b/poucave/html/js/app/components/Overview.mjs
@@ -26,10 +26,11 @@ export default class Overview extends Component {
 
   render({ checks, results }) {
     // Show the loading checks that were previously failing.
+    // Do not list the errors if a response could not be obtained.
     const failing = Object.values(results).filter(
       (r) =>
         (r.isLoading && this.failing.has(`${r.project}.${r.name}`)) ||
-        (!r.isLoading && !r.success)
+        (!r.isLoading && !r.isIncomplete && !r.success)
     );
 
     const isHealthy = failing.length == 0;
@@ -56,9 +57,9 @@ export default class Overview extends Component {
             <p>
               <strong
                 >The system
-                ${isHealthy
-                  ? "is currently healthy"
-                  : "has failing checks"}.</strong
+                ${
+                  isHealthy ? " is currently healthy" : " has failing checks"
+                }.</strong
               >
               <br />
               <span class="text-gray-medium">

--- a/poucave/html/js/app/components/Project.mjs
+++ b/poucave/html/js/app/components/Project.mjs
@@ -6,8 +6,8 @@ export default class Project extends Component {
   renderStatus() {
     const { checks } = this.props;
 
-    const isLoading = checks.some(c => c.result.isLoading);
-    const isHealthy = checks.every(c => c.result.success);
+    const isLoading = checks.some((c) => c.result.isLoading);
+    const isHealthy = checks.every((c) => c.result.success);
 
     let color = "bg-gray";
     let status = "loading";
@@ -16,43 +16,37 @@ export default class Project extends Component {
       status = isHealthy ? "Healthy" : "Unhealthy";
     }
 
-    return html`
-      <span class="badge ${color}">${status}</span>
-    `;
+    return html` <span class="badge ${color}">${status}</span> `;
   }
 
   renderChecks() {
     const { checks, fetchCheckResult } = this.props;
 
-    return checks.map(c => (html`
-      <${FocusedCheck.Consumer}>
-        ${
-          focusedCheckContext => (html`
+    return checks.map(
+      (c) => html`
+        <${FocusedCheck.Consumer}>
+          ${(focusedCheckContext) => html`
             <${Check}
               data="${c.data}"
               result="${c.result}"
               fetchCheckResult="${fetchCheckResult}"
               focusedCheckContext="${focusedCheckContext}"
             />
-          `)
-        }
-      </>
-    `))
+          `}
+        </${FocusedCheck.Consumer}>
+      `
+    );
   }
 
   render({ name }) {
     return html`
       <section class="project mt-3 pt-4">
-        <div class="float-right mt-1 lh-1">
-          ${this.renderStatus()}
-        </div>
+        <div class="float-right mt-1 lh-1">${this.renderStatus()}</div>
         <h3 class="mb-4">
           <i class="fa fa-layer-group mr-2"></i>
           <span class="project-name">${name}</span>
         </h3>
-        <div class="project-cards mb-1">
-          ${this.renderChecks()}
-        </div>
+        <div class="project-cards mb-1">${this.renderChecks()}</div>
       </section>
     `;
   }

--- a/poucave/html/js/app/components/SystemDiagram.mjs
+++ b/poucave/html/js/app/components/SystemDiagram.mjs
@@ -34,7 +34,7 @@ export default class SystemDiagram extends Component {
     }
 
     const svgDoc = this.svgRef.current.contentDocument;
-    Object.keys(results).forEach(k => {
+    Object.keys(results).forEach((k) => {
       const c = checks[k];
       const r = results[k];
       const indicator = svgDoc.getElementById(`${c.project}--${c.name}`);
@@ -45,7 +45,10 @@ export default class SystemDiagram extends Component {
           indicator.setAttribute("cursor", "pointer");
 
           // Add tooltip
-          const tooltip = document.createElementNS("http://www.w3.org/2000/svg", "title");
+          const tooltip = document.createElementNS(
+            "http://www.w3.org/2000/svg",
+            "title"
+          );
           tooltip.textContent = `${c.project}/${c.name}:\n${c.description}`;
           indicator.appendChild(tooltip);
 
@@ -68,7 +71,7 @@ export default class SystemDiagram extends Component {
     const diagramClass = diagramReady ? "" : "invisible";
     const diagramCardClass = diagramHidden ? "d-none" : "";
 
-    const isLoading = Object.values(results).some(r => r.isLoading);
+    const isLoading = Object.values(results).some((r) => r.isLoading);
 
     let loader = null;
     if (isLoading) {

--- a/poucave/html/js/app/components/TimeAgo.mjs
+++ b/poucave/html/js/app/components/TimeAgo.mjs
@@ -7,7 +7,7 @@ export default class TimeAgo extends Component {
     this.state = {
       timeago: "some time ago",
       timeoutId: null,
-    }
+    };
   }
 
   componentDidMount() {
@@ -22,7 +22,8 @@ export default class TimeAgo extends Component {
     }
 
     const isDateNewlySet = date && !prevProps.date;
-    const isDateChanged = date &&  prevProps.date && date.getTime() !== prevProps.date.getTime();
+    const isDateChanged =
+      date && prevProps.date && date.getTime() !== prevProps.date.getTime();
     if (isDateNewlySet || isDateChanged) {
       clearTimeout(timeoutId);
       this.refresh();
@@ -64,8 +65,8 @@ export default class TimeAgo extends Component {
   }
 
   render({ date }) {
-    const isoDate = date ? date.toISOString() : '';
-    const title = date ? date.toString() : '';
+    const isoDate = date ? date.toISOString() : "";
+    const title = date ? date.toString() : "";
     return html`
       <time datetime="${isoDate}" title="${title}">
         ${this.state.timeago}

--- a/poucave/html/js/app/constants.mjs
+++ b/poucave/html/js/app/constants.mjs
@@ -1,7 +1,8 @@
-export const DOMAIN = window.location.href.split('/')[2];
+export const DOMAIN = window.location.href.split("/")[2];
 export const ROOT_URL = `${window.location.protocol}//${DOMAIN}`;
 
-export const IS_DARK_MODE = window.matchMedia('(prefers-color-scheme: dark)').matches;
+export const IS_DARK_MODE = window.matchMedia("(prefers-color-scheme: dark)")
+  .matches;
 
 export const PLOT_COLORS = {
   MARKERS_FAILURE: "#fa4654",

--- a/poucave/html/js/app/index.mjs
+++ b/poucave/html/js/app/index.mjs
@@ -1,6 +1,6 @@
 import { html, render } from "../htm_preact.mjs";
 
-import App from "./components/App.mjs"
+import App from "./components/App.mjs";
 
 // Initialize the app on page load
 window.addEventListener("load", () => {


### PR DESCRIPTION
Sometimes, after waking up my laptop from suspend, I find my Poucave tab full of errors. 

Since this usually happens in the morning, I get this rollercoaster, because I quickly realize it's because of failing requests (and not failing checks).

These changes will hide the failed requests from the list of failing checks, and show the check details data in distinct colors based on the situation.
