### PR TITLE
Fix #863: use configured service name in UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Server configuration is done via environment variables:
 * ``REQUESTS_MAX_RETRIES``: Number of retries for HTTP requests (default: ``4``)
 * ``SENTRY_DSN``: Report errors to the specified Sentry ``"https://<key>@sentry.io/<project>"`` (default: disabled)
 * ``SERVICE_NAME``: Name of the running service, used to link known issues in bug tracker (default: ``poucave``)
+* ``SERVICE_TITLE``: Title shown in the UI (default: capitalized service name)
 
 * ``BUGTRACKER_URL``: Bug tracker URL. Set to empty string to disable. (default: ``https://bugzilla.mozilla.org``)
 * ``BUGTRACKER_API_KEY``: Bug tracker API key to fetch non-public bugs (default: none)

--- a/poucave/app.py
+++ b/poucave/app.py
@@ -200,6 +200,7 @@ async def hello(request):
     body = {
         "hello": "poucave",
         "service": config.SERVICE_NAME,
+        "title": config.SERVICE_TITLE or config.SERVICE_NAME.capitalize(),
         "environment": config.ENV_NAME,
     }
     return web.json_response(body)

--- a/poucave/config.py
+++ b/poucave/config.py
@@ -10,6 +10,7 @@ from decouple import config
 HOST = config("HOST", default="0.0.0.0")  # nosec
 PORT = config("PORT", default=8000, cast=int)
 SERVICE_NAME = config("SERVICE_NAME", default="poucave")
+SERVICE_TITLE = config("SERVICE_TITLE", default="")
 BUGTRACKER_URL = config("BUGTRACKER_URL", default="https://bugzilla.mozilla.org")
 BUGTRACKER_API_KEY = config("BUGTRACKER_API_KEY", default="")
 BUGTRACKER_TTL = config("BUGTRACKER_TTL", default=3600, cast=int)

--- a/poucave/html/index.html
+++ b/poucave/html/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Delivery System Status</title>
+  <title></title>
   <link rel="stylesheet" href="css/font-awesome.min.css" />
   <link rel="stylesheet" href="css/tabler.min.css" />
   <link rel="stylesheet" href="css/tabler-dark.min.css" />

--- a/poucave/html/index.html
+++ b/poucave/html/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title></title>
+  <title>Loading...</title>
   <link rel="stylesheet" href="css/font-awesome.min.css" />
   <link rel="stylesheet" href="css/tabler.min.css" />
   <link rel="stylesheet" href="css/tabler-dark.min.css" />

--- a/poucave/html/js/app/components/App.mjs
+++ b/poucave/html/js/app/components/App.mjs
@@ -2,16 +2,16 @@ import { html } from "../../htm_preact.mjs";
 
 import Dashboard from "./Dashboard.mjs";
 
-const App = () => {
+const App = ({ pageTitle }) => {
   return html`
     <div class="auto-theme-dark">
       <div class="page overflow-auto pb-6">
         <div class="flex-fill">
           <div class="header py-3">
             <div class="container">
-              <h3 class="my-0">
+              <h3 id="page-title" class="my-0">
                 <i class="fa fa-tachometer-alt mr-2"></i>
-                Delivery System Status
+                ${pageTitle}
               </h3>
             </div>
           </div>

--- a/poucave/html/js/app/components/App.mjs
+++ b/poucave/html/js/app/components/App.mjs
@@ -9,7 +9,7 @@ const App = ({ pageTitle }) => {
         <div class="flex-fill">
           <div class="header py-3">
             <div class="container">
-              <h3 id="page-title" class="my-0">
+              <h3 class="my-0">
                 <i class="fa fa-tachometer-alt mr-2"></i>
                 ${pageTitle}
               </h3>

--- a/poucave/html/js/app/index.mjs
+++ b/poucave/html/js/app/index.mjs
@@ -1,11 +1,29 @@
 import { html, render } from "../htm_preact.mjs";
 
 import App from "./components/App.mjs";
+import { ROOT_URL } from "./constants.mjs";
 
 // Initialize the app on page load
-window.addEventListener("load", () => {
+window.addEventListener("load", async () => {
   // Clear the application container and render the application
   const appContainer = document.getElementById("app");
   appContainer.innerHTML = "";
-  render(html`<${App} />`, appContainer);
+
+  // Fetch instance metadata.
+  const resp = await fetch(new URL("/", ROOT_URL));
+  const { service } = await resp.json();
+  const title = capitalize(service);
+  document.title = title;
+
+  render(html`<${App} pageTitle=${title} />`, appContainer);
 });
+
+
+function capitalize(str) {
+  return str.replace(/[\W_]+/g, " ")
+    .split(" ")
+    .map(word => {
+      return word[0].toUpperCase() + word.substring(1);
+    })
+    .join(" ");
+}

--- a/poucave/html/js/app/index.mjs
+++ b/poucave/html/js/app/index.mjs
@@ -11,19 +11,8 @@ window.addEventListener("load", async () => {
 
   // Fetch instance metadata.
   const resp = await fetch(new URL("/", ROOT_URL));
-  const { service } = await resp.json();
-  const title = capitalize(service);
+  const { title } = await resp.json();
   document.title = title;
 
   render(html`<${App} pageTitle=${title} />`, appContainer);
 });
-
-
-function capitalize(str) {
-  return str.replace(/[\W_]+/g, " ")
-    .split(" ")
-    .map(word => {
-      return word[0].toUpperCase() + word.substring(1);
-    })
-    .join(" ");
-}

--- a/poucave/utils.py
+++ b/poucave/utils.py
@@ -311,9 +311,8 @@ class BugTracker:
             buglist = self.cache.get(cache_key) if self.cache else None
 
             if buglist is None:
-                service_name = config.SERVICE_NAME.lower()
                 env_name = config.ENV_NAME or ""
-                url = f"{config.BUGTRACKER_URL}/rest/bug?whiteboard={service_name} {env_name}"
+                url = f"{config.BUGTRACKER_URL}/rest/bug?whiteboard={config.SERVICE_NAME} {env_name}"
                 try:
                     buglist = await fetch_json(
                         url, headers={"X-BUGZILLA-API-KEY": config.BUGTRACKER_API_KEY}

--- a/poucave/utils.py
+++ b/poucave/utils.py
@@ -311,8 +311,9 @@ class BugTracker:
             buglist = self.cache.get(cache_key) if self.cache else None
 
             if buglist is None:
+                service_name = config.SERVICE_NAME.lower()
                 env_name = config.ENV_NAME or ""
-                url = f"{config.BUGTRACKER_URL}/rest/bug?whiteboard={config.SERVICE_NAME} {env_name}"
+                url = f"{config.BUGTRACKER_URL}/rest/bug?whiteboard={service_name} {env_name}"
                 try:
                     buglist = await fetch_json(
                         url, headers={"X-BUGZILLA-API-KEY": config.BUGTRACKER_API_KEY}


### PR DESCRIPTION
Fix #863

Using `SERVICE_NAME="telescope-firefox-CI"` when running the app, the UI will show `Telescope Firefox CI`.

Note that the service name is also used to pull tickets from Bugzilla whose *whiteboard* field contains the configured string.