### PR TITLE
Fix #851: check latest indexed (part 1)

### DIFF
--- a/checks/taskcluster/latest_indexed.py
+++ b/checks/taskcluster/latest_indexed.py
@@ -65,7 +65,7 @@ async def run(
         if getattr(e, "status_code") != 404:
             raise
         # No indexed task found. Failing.
-        return False, f"No task found at {index_path:!r}"
+        return False, f"No task found at {index_path!r}"
 
     # 2. Inspect the task using the queue.
     queue = taskcluster.aio.Queue(options)

--- a/checks/taskcluster/latest_indexed.py
+++ b/checks/taskcluster/latest_indexed.py
@@ -48,7 +48,7 @@ async def run(
         params.access_token = "${TASKCLUSTER_ACCESS_TOKEN}"
         params.max_age = 360
         params.index_path = "project.taskcluster.telescope.poucave-issue-851-test.07"
-        params.artifacts_names = ["public/result/status.json"]
+        params.artifacts_names = ["public/results/status.json"]
 
     """
     # Build connection infos from parameters.

--- a/checks/taskcluster/latest_indexed.py
+++ b/checks/taskcluster/latest_indexed.py
@@ -3,7 +3,7 @@ A check to verify that a task exists for the specified index path, that it ran r
 and published the expected artifact.
 
 This check can be used to verify that a certain hook (defined elsewhere) is
-regurlarly triggered as expected.
+regularly triggered as expected.
 
 Information about the lastest indexed task is returned.
 """

--- a/checks/taskcluster/latest_indexed.py
+++ b/checks/taskcluster/latest_indexed.py
@@ -1,0 +1,100 @@
+"""
+A check to verify that a task exists for the specified index path, that it ran recently,
+and published the expected artifact.
+
+This check can be used to verify that a certain hook (defined elsewhere) is
+regurlarly triggered as expected.
+
+Information about the lastest indexed task is returned.
+"""
+import logging
+from typing import List
+
+import taskcluster
+import taskcluster.aio
+import taskcluster.exceptions
+
+from poucave import utils
+from poucave.typings import CheckResult
+
+from . import utils as tc_utils
+
+
+logger = logging.getLogger(__name__)
+
+# List which check parameters are visible in the UI.
+EXPOSED_PARAMETERS = ["root_url", "index_path", "max_age"]
+
+
+async def run(
+    max_age: int,
+    index_path: str,
+    artifacts_names: List[str],
+    root_url: str,
+    client_id: str = "",
+    access_token: str = "",
+    certificate: str = "",
+) -> CheckResult:
+    """
+    Example configuration:
+
+    .. code-block:: toml
+
+        [checks.queue.latest-indexed]
+        description = ""
+        module = "checks.taskcluster.latest_indexed"
+        params.root_url = "${TASKCLUSTER_ROOT_URL}"
+        params.client_id = "${TASKCLUSTER_CLIENT_ID}"
+        params.access_token = "${TASKCLUSTER_ACCESS_TOKEN}"
+        params.max_age = 360
+        params.index_path = "project.taskcluster.telescope.poucave-issue-851-test.07"
+        params.artifacts_names = ["public/result/status.json"]
+
+    """
+    # Build connection infos from parameters.
+    options = tc_utils.options_from_params(
+        root_url, client_id, access_token, certificate
+    )
+
+    # 1. Get the task id from the index
+    index = taskcluster.aio.Index(options)
+    try:
+        indexed_task = await index.findTask(index_path)
+        task_id = indexed_task["taskId"]
+    except taskcluster.exceptions.TaskclusterRestFailure as e:
+        if getattr(e, "status_code") != 404:
+            raise
+        # No indexed task found. Failing.
+        return False, f"No task found at {index_path:!r}"
+
+    # 2. Make sure artifacts exists.
+    # XXX: This fails with an obscure error about credentials:
+    # futures = [index.findArtifactFromTask(index_path, a) for a in artifacts_names]
+    # results = await utils.run_parallel(*futures)
+
+    # XXX: using an alternative way. Use the queue.
+    queue = taskcluster.aio.Queue(options)
+    futures = [queue.latestArtifactInfo(task_id, a) for a in artifacts_names]
+    try:
+        artifacts = await utils.run_parallel(*futures)
+    except taskcluster.exceptions.TaskclusterRestFailure as e:
+        failed_call = e.body["requestInfo"]["params"]
+        return False, "Artifact {name!r} of task {taskId!r} not available".format(
+            **failed_call
+        )
+
+    # 3. Verify that latest run is not too old.
+    status = await queue.status(task_id)
+    last_run = status["status"]["runs"][-1]
+    resolved_at = utils.utcfromisoformat(last_run["resolved"])
+    age_task = utils.utcnow() - resolved_at
+    if age_task.seconds > max_age:
+        return (
+            False,
+            f"Latest task at {index_path!r} ({task_id!r}) is {age_task.seconds} seconds old",
+        )
+
+    return True, {
+        **status,
+        "artifacts": artifacts,
+    }

--- a/checks/taskcluster/utils.py
+++ b/checks/taskcluster/utils.py
@@ -1,0 +1,31 @@
+from poucave import config, utils
+
+
+def options_from_params(root_url, client_id, access_token, certificate):
+    return {
+        "rootUrl": root_url,
+        "credentials": (
+            {"clientId": client_id, "accessToken": access_token}
+            if client_id and access_token
+            else {"certificate": certificate}
+        ),
+        "maxRetries": config.REQUESTS_MAX_RETRIES,
+    }
+
+
+async def list_artifacts(queue, task_id, run_id):
+    """Helper to list all task artifacts."""
+    page = await queue.listArtifacts(task_id, run_id)
+    artifacts = page.get("artifacts", [])
+    while page.get("continuationToken"):
+        artifacts += page.get("artifacts", [])
+        page = await queue.listArtifacts(
+            task_id,
+            run_id,
+            query={"continuationToken": page.get("continuationToken")},
+        )
+    futures = [
+        queue.artifact(task_id, run_id, artifact["name"]) for artifact in artifacts
+    ]
+    infos = await utils.run_parallel(*futures)
+    return infos

--- a/checks/taskcluster/utils.py
+++ b/checks/taskcluster/utils.py
@@ -11,21 +11,3 @@ def options_from_params(root_url, client_id, access_token, certificate):
         ),
         "maxRetries": config.REQUESTS_MAX_RETRIES,
     }
-
-
-async def list_artifacts(queue, task_id, run_id):
-    """Helper to list all task artifacts."""
-    page = await queue.listArtifacts(task_id, run_id)
-    artifacts = page.get("artifacts", [])
-    while page.get("continuationToken"):
-        artifacts += page.get("artifacts", [])
-        page = await queue.listArtifacts(
-            task_id,
-            run_id,
-            query={"continuationToken": page.get("continuationToken")},
-        )
-    futures = [
-        queue.artifact(task_id, run_id, artifact["name"]) for artifact in artifacts
-    ]
-    infos = await utils.run_parallel(*futures)
-    return infos

--- a/checks/taskcluster/utils.py
+++ b/checks/taskcluster/utils.py
@@ -1,4 +1,4 @@
-from poucave import config, utils
+from poucave import config
 
 
 def options_from_params(root_url, client_id, access_token, certificate):

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,7 +9,7 @@ elif [ $1 == "check" ]; then
 elif [ $1 == "test" ]; then
     # Note: poetry has no option to only install dev dependencies.
     # https://github.com/python-poetry/poetry/issues/2572
-    poetry install --extras=remotesettings
+    poetry install --extras=remotesettings --extras=taskcluster
     poetry run pytest tests
 
 else

--- a/tests/checks/taskcluster/test_latest_indexed.py
+++ b/tests/checks/taskcluster/test_latest_indexed.py
@@ -6,7 +6,6 @@ import taskcluster.exceptions
 
 from checks.taskcluster.latest_indexed import run
 from poucave.utils import utcnow
-from tests.utils import patch_async
 
 
 MODULE = "checks.taskcluster.latest_indexed"

--- a/tests/checks/taskcluster/test_latest_indexed.py
+++ b/tests/checks/taskcluster/test_latest_indexed.py
@@ -1,0 +1,121 @@
+from datetime import timedelta
+from unittest import mock
+
+import pytest
+import taskcluster.exceptions
+
+from checks.taskcluster.latest_indexed import run
+from poucave.utils import utcnow
+from tests.utils import patch_async
+
+
+MODULE = "checks.taskcluster.latest_indexed"
+
+PARAMS = {
+    "root_url": "http://server",
+    "index_path": "project.myproject.task",
+    "artifacts_names": ["public/status.json"],
+    "max_age": 10,
+}
+
+
+@pytest.fixture
+def fake_index():
+    class FakeIndex:
+        async def findTask(self, *args, **kwargs):
+            return {"taskId": "task-42"}
+
+    fake_index = FakeIndex()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Index", return_value=fake_index) as m:
+        yield m
+
+
+@pytest.fixture
+def fake_queue():
+    class FakeQueue:
+        async def latestArtifactInfo(self, task_id, a):
+            return {}
+
+        async def status(self, task_id):
+            task_status = {
+                "runs": [{"resolved": (utcnow() - timedelta(seconds=5)).isoformat()}]
+            }
+            return {"status": task_status}
+
+    fake_queue = FakeQueue()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Queue", return_value=fake_queue) as m:
+        yield m
+
+
+async def test_positive(fake_index, fake_queue):
+    status, data = await run(**PARAMS)
+
+    assert status is True
+    assert "artifacts" in data
+    assert "status" in data
+
+
+async def test_index_errors_are_raised():
+    class FakeIndex:
+        async def findTask(self, *args, **kwargs):
+            e = taskcluster.exceptions.TaskclusterRestFailure("", None)
+            raise e
+
+    fake_index = FakeIndex()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Index", return_value=fake_index):
+        with pytest.raises(taskcluster.exceptions.TaskclusterRestFailure):
+            await run(**PARAMS)
+
+
+async def test_negative_missing_task():
+    class FakeIndex:
+        async def findTask(self, *args, **kwargs):
+            e = taskcluster.exceptions.TaskclusterRestFailure("", None)
+            e.status_code = 404
+            raise e
+
+    fake_index = FakeIndex()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Index", return_value=fake_index):
+        status, data = await run(**PARAMS)
+
+    assert status is False
+    assert data == "No task found at 'project.myproject.task'"
+
+
+async def test_negative_fail_artifact(fake_index):
+    class FakeQueue:
+        async def latestArtifactInfo(self, task_id, a):
+            e = taskcluster.exceptions.TaskclusterRestFailure("", None)
+            e.body = {"requestInfo": {"params": {"name": a, "taskId": task_id}}}
+            raise e
+
+    fake_queue = FakeQueue()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Queue", return_value=fake_queue):
+        status, data = await run(**PARAMS)
+
+    assert status is False
+    assert data == "Artifact 'public/status.json' of task 'task-42' not available"
+
+
+async def test_negative_task_too_told(fake_index):
+    class FakeQueue:
+        async def latestArtifactInfo(self, task_id, a):
+            return {}
+
+        async def status(self, task_id):
+            return {
+                "status": {
+                    "runs": [
+                        {"resolved": (utcnow() - timedelta(seconds=11)).isoformat()}
+                    ]
+                }
+            }
+
+    fake_queue = FakeQueue()
+    with mock.patch(f"{MODULE}.taskcluster.aio.Queue", return_value=fake_queue):
+        status, data = await run(**PARAMS)
+
+    assert status is False
+    assert (
+        "Latest task at 'project.myproject.task' ('task-42') is 11 seconds old" in data
+    )


### PR DESCRIPTION
This runs fine at home, with the config shown in docstring

```
TASKCLUSTER_ROOT_URL=https://community-tc.services.mozilla.com TASKCLUSTER_CLIENT_ID=xxxxxxxxx TASKCLUSTER_ACCESS_TOKEN=xxxxxxxx CONFIG_FILE=taskcluster.toml make check project=queue check=latest-indexed
```