### PR TITLE
Fix wrong default port number in README.md (8080 -> 8000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Server configuration is done via environment variables:
 * ``CORS_ORIGIN``: Allowed requests origins (default: ``*``)
 * ``ENV_NAME``: A string to identify the current environment name like ``"prod"`` or ``"stage"`` (default: None)
 * ``HOST``: Bind to host (default: ``"localhost"``)
-* ``PORT``: Listen on port (default: ``8080``)
+* ``PORT``: Listen on port (default: ``8000``)
 * ``DEFAULT_TTL``: Default TTL for endpoints in seconds (default: ``60``)
 * ``DEFAULT_REQUEST_HEADERS``: Default headers sent in every HTTP requests, as JSON dict format (example: ``{"Allow-Access": "CDN"}``, default: ``{}``)
 * ``LOG_LEVEL``: One of ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``, ``CRITICAL`` (default: ``INFO``)


### PR DESCRIPTION
I think the default port is [8000](https://github.com/mozilla-services/poucave/blob/f72fef8daea15c5b2b57305a6f8ae058bd829bef/poucave/config.py#L11) rather than 8080.