### PR TITLE
Add cProfile to understand CPU bottlenecks

### DIFF
--- a/telescope/config.py
+++ b/telescope/config.py
@@ -77,6 +77,7 @@ CURL_BINARY_PATH = config("CURL_BINARY_PATH", default="curl")
 REDIS_CACHE_URL = config("REDIS_CACHE_URL", default="")
 REDIS_KEY_PREFIX = config("REDIS_KEY_PREFIX", default="telescope:")
 CACHE_LOCK_ENABLED = config("CACHE_LOCK_ENABLED", default=True, cast=bool)
+PROFILING_ENABLED = config("PROFILING_ENABLED", default=False, cast=bool)
 
 
 def interpolate_env(d):

--- a/telescope/middleware.py
+++ b/telescope/middleware.py
@@ -65,3 +65,14 @@ async def error_middleware(request, handler):
 
     body = {"success": False, "data": repr(error), **request.match_info}
     return web.json_response(body, status=web.HTTPInternalServerError.status_code)
+
+
+@web.middleware
+async def profile_middleware(request, handler):
+    profiler = request.app["telescope.profiler"]
+    profiler.enable()
+    try:
+        response = await handler(request)
+    finally:
+        profiler.disable()
+    return response

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -121,6 +121,20 @@ class DummyLock:
         return self
 
 
+class DummyProfiler:
+    def enable(self):
+        pass
+
+    def disable(self):
+        pass
+
+    def dump_stats(self, filename):
+        pass
+
+    def clear(self):
+        pass
+
+
 retry_decorator = backoff.on_exception(
     backoff.expo,
     (aiohttp.ClientError, asyncio.TimeoutError),

--- a/tests/test_basic_endpoints.py
+++ b/tests/test_basic_endpoints.py
@@ -1,3 +1,4 @@
+import cProfile
 import logging
 import re
 import tempfile
@@ -70,6 +71,20 @@ async def test_version(cli):
     config.VERSION_FILE = "missing.json"
     response = await cli.get("/__version__")
     assert response.status == 500
+
+
+async def test_profile_disabled(cli):
+    response = await cli.get("/__cprofile__")
+    assert response.status == 404
+
+
+async def test_profile_enabled(cli):
+    cli.app["telescope.profiler"] = cProfile.Profile()
+    await cli.get("/__heartbeat__")  # Warm up profiler.
+
+    response = await cli.get("/__cprofile__")
+    assert response.status == 200
+    assert response.headers["Content-Type"] == "application/octet-stream"
 
 
 # /checks


### PR DESCRIPTION

<img width="677" height="343" alt="Screenshot 2025-11-18 at 13 05 19" src="https://github.com/user-attachments/assets/1cce3c60-566a-4b7c-a1f5-b6eb99b8ad99" />



Note: locally, when loading all prod checks, I don't have bottleneck. Biggest time is IO with cold cache
<img width="1273" height="183" alt="Screenshot 2025-11-18 at 13 02 19" src="https://github.com/user-attachments/assets/2b80b030-23ba-4f4e-b870-b13cdd8951c5" />

> That line again means your app is mostly idle in the event loop, not burning CPU.
>
> <method 'control' of 'select.kqueue' objects> is macOS’s I/O selector (what asyncio and aiohttp use under the hood). It spends most of the time waiting for network sockets to be ready.
> 
> Seeing it dominate is normal for servers that are mostly waiting on I/O. It tells you:
> 
> Python threads are mostly sleeping, waiting for sockets to be readable/writable.
> 
> The CPU is not your bottleneck — requests are waiting on network, database, or external services.