### PR TITLE
Compare collection timestamps, not records timestamps

### DIFF
--- a/checks/remotesettings/server_compare.py
+++ b/checks/remotesettings/server_compare.py
@@ -63,9 +63,11 @@ async def run(
     for entry, origin_changeset, target_changeset in zip(
         source_entries, source_changesets, target_changesets
     ):
+        # We compare the collection metadata last_modified timestamp,
+        # as it also reflects the signature refresh.
         source_metadata_timestamp, target_metadata_timestamp = (
-            origin_changeset["timestamp"],
-            target_changeset["timestamp"],
+            origin_changeset["metadata"]["last_modified"],
+            target_changeset["metadata"]["last_modified"],
         )
 
         source_age_seconds = utcnow().timestamp() - (source_metadata_timestamp / 1000)

--- a/tests/checks/remotesettings/test_server_compare.py
+++ b/tests/checks/remotesettings/test_server_compare.py
@@ -31,11 +31,11 @@ async def test_positive(mock_aioresponses):
     changeset_url = CHANGESET_URL.format("bid", "cid", 42)
     mock_aioresponses.get(
         source_url + changeset_url,
-        payload={"timestamp": 123, "metadata": {"last_modified": 123}},
+        payload={"metadata": {"last_modified": 123}},
     )
     mock_aioresponses.get(
         target_url + changeset_url,
-        payload={"timestamp": 123, "metadata": {"last_modified": 456}},
+        payload={"metadata": {"last_modified": 123}},
     )
 
     status, data = await run(source_url, target_url)
@@ -65,9 +65,11 @@ async def test_positive_min_age(mock_aioresponses):
     changeset_url = CHANGESET_URL.format("bid", "cid", 42)
     mock_aioresponses.get(
         source_url + changeset_url,
-        payload={"timestamp": fresh_timestamp},
+        payload={"metadata": {"last_modified": fresh_timestamp}},
     )
-    mock_aioresponses.get(target_url + changeset_url, payload={"timestamp": 123})
+    mock_aioresponses.get(
+        target_url + changeset_url, payload={"metadata": {"last_modified": 123}}
+    )
 
     with mock.patch(f"{MODULE}.utcnow", return_value=fake_now):
         status, data = await run(source_url, target_url)
@@ -91,8 +93,12 @@ async def test_negative(mock_aioresponses):
     )
 
     changeset_url = CHANGESET_URL.format("bid", "cid", 42)
-    mock_aioresponses.get(source_url + changeset_url, payload={"timestamp": 456})
-    mock_aioresponses.get(target_url + changeset_url, payload={"timestamp": 123})
+    mock_aioresponses.get(
+        source_url + changeset_url, payload={"metadata": {"last_modified": 456}}
+    )
+    mock_aioresponses.get(
+        target_url + changeset_url, payload={"metadata": {"last_modified": 123}}
+    )
 
     status, data = await run(source_url, target_url)
 


### PR DESCRIPTION
This is basically a revert of #1638 

By only comparing records timestamps, we were ignoring outdated signatures in collections metadata.

Alternatively, we can cancel this PR and add cert expiration / signature verification on the /v2 endpoint