### PR TITLE
Fix git-source lag logics

### DIFF
--- a/checks/remotesettings/git_reader_commit.py
+++ b/checks/remotesettings/git_reader_commit.py
@@ -6,7 +6,7 @@ The git reader commit and the repo latest commit details are returned.
 
 from telescope import config
 from telescope.typings import CheckResult
-from telescope.utils import fetch_json, utcfromisoformat, utcnow
+from telescope.utils import fetch_json, utcfromisoformat
 
 
 EXPOSED_PARAMETERS = ["server", "repo", "lag_margin_seconds"]
@@ -32,12 +32,13 @@ async def run(
     server_info = await fetch_json(server + "/")
     git_info = server_info["git"]["common"]
     source_commit = git_info["id"]
+    commit_datetime = git_info["datetime"]
 
     latest_sha = details["commit"]["sha"]
     latest_datetime = details["commit"]["commit"]["author"]["date"]
 
     is_recent = (
-        utcnow() - utcfromisoformat(latest_datetime)
+        utcfromisoformat(latest_datetime) - utcfromisoformat(commit_datetime)
     ).total_seconds() < lag_margin_seconds
 
     return (

--- a/tests/checks/remotesettings/test_git_reader_commit.py
+++ b/tests/checks/remotesettings/test_git_reader_commit.py
@@ -1,6 +1,3 @@
-from datetime import datetime, timezone
-from unittest import mock
-
 from checks.remotesettings.git_reader_commit import run
 
 
@@ -78,6 +75,7 @@ async def test_positive_latency(mock_aioresponses):
                 "common": {
                     # Different source commit.
                     "id": "7a50f5506e0a3e4a28e6761645da6e3e1276a5cc",  # pragma: allowlist secret
+                    # Latest commit date is within lag margin.
                     "datetime": "2025-02-25T18:02:02Z",
                 }
             },
@@ -90,12 +88,7 @@ async def test_positive_latency(mock_aioresponses):
         payload=GITHUB_EXAMPLE_COMMIT,
     )
 
-    # Less than 30min after commit was made.
-    fake_now = datetime(2025, 2, 25, 18, 30, 0, tzinfo=timezone.utc)
-    with mock.patch(
-        "checks.remotesettings.git_reader_commit.utcnow", return_value=fake_now
-    ):
-        status, data = await run(server=url, repo="mozilla/remote-settings-data")
+    status, data = await run(server=url, repo="mozilla/remote-settings-data")
 
     assert status is True
     assert (
@@ -123,7 +116,7 @@ async def test_negative(mock_aioresponses):
                 "common": {
                     # Different source commit.
                     "id": "7a50f5506e0a3e4a28e6761645da6e3e1276a5cc",  # pragma: allowlist secret
-                    "datetime": "2025-02-25T18:02:02Z",
+                    "datetime": "2025-02-25T17:02:02Z",
                 }
             },
         },
@@ -147,7 +140,7 @@ async def test_negative(mock_aioresponses):
             },
             "source_commit": {
                 "sha": "7a50f5506e0a3e4a28e6761645da6e3e1276a5cc",  # pragma: allowlist secret
-                "date": "2025-02-25T18:02:02Z",
+                "date": "2025-02-25T17:02:02Z",
             },
         }
     )


### PR DESCRIPTION
Shouldn't it be this way? 

Or should it have two parameters? lag margin + max age? 