### PR TITLE
Fix BigQuery heartbeat query

### DIFF
--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -754,9 +754,9 @@ class History:
         Returns `True` if we can successfully read our own logs from BigQuery.
         """
         try:
-            rows = await fetch_bigquery("""
+            rows = await fetch_bigquery(r"""
                 SELECT *
-                FROM `{{__project__}}.gke_telescope_{{__env__}}_log.stdout`
+                FROM `{__project__}.gke_telescope_{__env__}_log.stdout`
                 LIMIT 1
             """)
             return len(rows) > 0


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/RMST-416

The heartbeat query was taken from the main query which goes through a `.format()` call, hence the double `{}`.

With this fix, I get a different error locally (which makes sense since no env defined)