### PR TITLE
RMST-433: fix missing running loop for `TCPConnector`

### DIFF
--- a/telescope/config.py
+++ b/telescope/config.py
@@ -32,7 +32,7 @@ HISTORY_TTL = config("HISTORY_TTL", default=3600, cast=int)
 REFRESH_SECRET = config("REFRESH_SECRET", default="")
 REQUESTS_TIMEOUT_SECONDS = config("REQUESTS_TIMEOUT_SECONDS", default=10, cast=int)
 REQUESTS_CONNECT_TIMEOUT_SECONDS = config(
-    "REQUESTS_CONNECT_TIMEOUT_SECONDS", default=5, cast=int
+    "REQUESTS_CONNECT_TIMEOUT_SECONDS", default=5, cast=float
 )
 REQUESTS_DNS_CACHE_TTL_SECONDS = config(
     "REQUESTS_DNS_CACHE_TTL_SECONDS", default=60, cast=int

--- a/telescope/utils.py
+++ b/telescope/utils.py
@@ -345,6 +345,7 @@ def client_session_start(
         resolver=aiohttp.AsyncResolver(loop=resolver_loop),
         use_dns_cache=True,
         ttl_dns_cache=config.REQUESTS_DNS_CACHE_TTL_SECONDS,
+        loop=resolver_loop,
     )
     headers = {"User-Agent": "telescope", **config.DEFAULT_REQUEST_HEADERS}
     session = aiohttp.ClientSession(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -110,6 +110,8 @@ def test_executing_from_command_line(test_config_toml):
         env={
             "CONFIG_FILE": test_config_toml,
             **os.environ,
+            "REQUESTS_MAX_RETRIES": "0",
+            "REQUESTS_CONNECT_TIMEOUT_SECONDS": "0.1",
         },
     )
     assert result.returncode == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+import subprocess
 import sys
 from unittest import mock
 
@@ -90,3 +92,25 @@ async def test_observe_event_loop(cli, config):
     except StopAsyncIteration:
         pass
     assert pending_tasks_metric.labels("main")._value.get() >= 0
+
+
+def test_executing_from_command_line(test_config_toml):
+    project = "testproject"
+    check = "hb"
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "telescope",
+            "check",
+            project,
+            check,
+        ],
+        capture_output=True,
+        env={
+            "CONFIG_FILE": test_config_toml,
+            **os.environ,
+        },
+    )
+    assert result.returncode == 0
+    assert "Test HB" in result.stdout.decode()


### PR DESCRIPTION
When ran from command line (cronjob), TCPConnector was creating its own loop. Fix was to pass the main loop as param